### PR TITLE
style(): format codebase with dotnet-format

### DIFF
--- a/src/NvimClient.API/NvimAPI.cs
+++ b/src/NvimClient.API/NvimAPI.cs
@@ -86,7 +86,7 @@ namespace NvimClient.API
         var match = Regex.Match(serverAddress,
           @"\\\\(?'serverName'[^\\]+)\\pipe\\(?'pipeName'[^\\]+)");
         var serverName = match.Groups["serverName"].Value;
-        var pipeName   = match.Groups["pipeName"].Value;
+        var pipeName = match.Groups["pipeName"].Value;
         var pipeStream = new NamedPipeClientStream(serverName, pipeName,
           PipeDirection.InOut, PipeOptions.Asynchronous);
         pipeStream.Connect();
@@ -119,10 +119,10 @@ namespace NvimClient.API
     {
       var context = new SerializationContext();
       context.Serializers.Register(new NvimMessageSerializer(context));
-      _serializer   = MessagePackSerializer.Get<NvimMessage>(context);
-      _inputStream  = inputStream;
+      _serializer = MessagePackSerializer.Get<NvimMessage>(context);
+      _inputStream = inputStream;
       _outputStream = outputStream;
-      _messageQueue  = new BlockingCollection<NvimMessage>();
+      _messageQueue = new BlockingCollection<NvimMessage>();
       _pendingRequests = new ConcurrentDictionary<long, PendingRequest>();
       _handlers = new ConcurrentDictionary<string, NvimHandler>();
 
@@ -131,10 +131,10 @@ namespace NvimClient.API
     }
 
     public void RegisterHandler(string name, Func<object[], object> handler) =>
-      RegisterHandler(name, (Delegate) handler);
+      RegisterHandler(name, (Delegate)handler);
 
     public void RegisterHandler(string name, Action<object[]> handler) =>
-      RegisterHandler(name, (Delegate) handler);
+      RegisterHandler(name, (Delegate)handler);
 
     public void RegisterHandler(string name,
       Func<object[], Task<object>> handler) => RegisterHandler(name,
@@ -178,10 +178,10 @@ namespace NvimClient.API
     private void CallHandlerAndSendResponse(uint requestId, Delegate handler,
       object[] args)
     {
-      var response = new NvimResponse {MessageId = requestId};
+      var response = new NvimResponse { MessageId = requestId };
       try
       {
-        var result = handler.DynamicInvoke(new object[] {args});
+        var result = handler.DynamicInvoke(new object[] { args });
         response.Result = ConvertToMessagePackObject(result);
       }
       catch (Exception exception)
@@ -197,11 +197,11 @@ namespace NvimClient.API
       object error)
     {
       var response = new NvimResponse
-                     {
-                       MessageId = args.RequestId,
-                       Result    = ConvertToMessagePackObject(result),
-                       Error     = ConvertToMessagePackObject(error)
-                     };
+      {
+        MessageId = args.RequestId,
+        Result = ConvertToMessagePackObject(result),
+        Error = ConvertToMessagePackObject(error)
+      };
       _messageQueue.Add(response);
     }
 
@@ -223,15 +223,15 @@ namespace NvimClient.API
           var result = ConvertFromMessagePackObject(response.Result);
           if (typeof(TResult).IsArray)
           {
-            var objectArray = (object[]) result;
+            var objectArray = (object[])result;
             var resultArray = Array.CreateInstance(
               typeof(TResult).GetElementType(),
               objectArray.Length);
             Array.Copy(objectArray, resultArray, resultArray.Length);
-            return (TResult) (object) resultArray;
+            return (TResult)(object)resultArray;
           }
 
-          return (TResult) result;
+          return (TResult)result;
         });
     }
 
@@ -267,56 +267,56 @@ namespace NvimClient.API
         switch (message)
         {
           case NvimNotification notification:
-          {
-            if (notification.Method == "redraw")
             {
-              var uiEvents = notification.Arguments.AsEnumerable().SelectMany(
-                uiEvent =>
-                {
-                  var data = uiEvent.AsList();
-                  var name = data.First().AsString();
-                  return data.Select(args => new {Name = name, Args = args})
-                             .Skip(1);
-                });
-              foreach (var uiEvent in uiEvents)
+              if (notification.Method == "redraw")
               {
-                CallUIEventHandler(uiEvent.Name,
-                  (object[]) ConvertFromMessagePackObject(uiEvent.Args));
+                var uiEvents = notification.Arguments.AsEnumerable().SelectMany(
+                  uiEvent =>
+                  {
+                    var data = uiEvent.AsList();
+                    var name = data.First().AsString();
+                    return data.Select(args => new { Name = name, Args = args })
+                               .Skip(1);
+                  });
+                foreach (var uiEvent in uiEvents)
+                {
+                  CallUIEventHandler(uiEvent.Name,
+                    (object[])ConvertFromMessagePackObject(uiEvent.Args));
+                }
               }
-            }
 
-            var arguments =
-              (object[]) ConvertFromMessagePackObject(notification.Arguments);
-            if (_handlers.TryGetValue(notification.Method, out var handler))
-            {
-              handler(null, arguments);
-            }
-            else
-            {
-              OnUnhandledNotification?.Invoke(this,
-                new NvimUnhandledNotificationEventArgs(notification.Method,
-                  arguments));
-            }
+              var arguments =
+                (object[])ConvertFromMessagePackObject(notification.Arguments);
+              if (_handlers.TryGetValue(notification.Method, out var handler))
+              {
+                handler(null, arguments);
+              }
+              else
+              {
+                OnUnhandledNotification?.Invoke(this,
+                  new NvimUnhandledNotificationEventArgs(notification.Method,
+                    arguments));
+              }
 
-            break;
-          }
+              break;
+            }
           case NvimRequest request:
-          {
-            var arguments =
-              (object[]) ConvertFromMessagePackObject(request.Arguments);
-            if (_handlers.TryGetValue(request.Method, out var handler))
             {
-              handler(request.MessageId, arguments);
-            }
-            else
-            {
-              OnUnhandledRequest?.Invoke(this,
-                new NvimUnhandledRequestEventArgs(this, request.MessageId,
-                  request.Method, arguments));
-            }
+              var arguments =
+                (object[])ConvertFromMessagePackObject(request.Arguments);
+              if (_handlers.TryGetValue(request.Method, out var handler))
+              {
+                handler(request.MessageId, arguments);
+              }
+              else
+              {
+                OnUnhandledRequest?.Invoke(this,
+                  new NvimUnhandledRequestEventArgs(this, request.MessageId,
+                    request.Method, arguments));
+              }
 
-            break;
-          }
+              break;
+            }
           case NvimResponse response:
             if (!_pendingRequests.TryRemove(response.MessageId,
               out var pendingRequest))
@@ -343,7 +343,7 @@ namespace NvimClient.API
     {
       private readonly TimeSpan _responseTimeout = TimeSpan.FromSeconds(10);
       private readonly ManualResetEvent _receivedResponseEvent;
-      private NvimResponse _response;          
+      private NvimResponse _response;
 
       internal PendingRequest() =>
         _receivedResponseEvent = new ManualResetEvent(false);
@@ -366,7 +366,7 @@ namespace NvimClient.API
               else
               {
                 taskCompletionSource.SetResult(
-                  ((PendingRequest) state)._response);
+                  ((PendingRequest)state)._response);
               }
             },
             this, timeout, true);

--- a/src/NvimClient.API/NvimPlugin/Attributes/NvimAutocmdAttribute.cs
+++ b/src/NvimClient.API/NvimPlugin/Attributes/NvimAutocmdAttribute.cs
@@ -7,9 +7,9 @@ namespace NvimClient.API.NvimPlugin.Attributes
   {
     public NvimAutocmdAttribute(string name) => Name = name;
 
-    public string Name        { get; set; }
-    public string Group       { get; set; }
-    public bool   AllowNested { get; set; }
-    public string Pattern     { get; set; }
+    public string Name { get; set; }
+    public string Group { get; set; }
+    public bool AllowNested { get; set; }
+    public string Pattern { get; set; }
   }
 }

--- a/src/NvimClient.API/NvimPlugin/Attributes/NvimCommandAttribute.cs
+++ b/src/NvimClient.API/NvimPlugin/Attributes/NvimCommandAttribute.cs
@@ -5,14 +5,14 @@ namespace NvimClient.API.NvimPlugin.Attributes
   [AttributeUsage(AttributeTargets.Method)]
   public class NvimCommandAttribute : Attribute
   {
-    public string Addr     { get; set; }
+    public string Addr { get; set; }
     public string Complete { get; set; }
-    public long   Count    { get; set; }
-    public string Eval     { get; set; }
-    public string Range    { get; set; }
-    public bool   Register { get; set; }
-    public string NArgs    { get; set; }
-    public string Name     { get; set; }
-    public bool   Bar      { get; set; }
+    public long Count { get; set; }
+    public string Eval { get; set; }
+    public string Range { get; set; }
+    public bool Register { get; set; }
+    public string NArgs { get; set; }
+    public string Name { get; set; }
+    public bool Bar { get; set; }
   }
 }

--- a/src/NvimClient.API/NvimPlugin/Attributes/NvimFunctionAttribute.cs
+++ b/src/NvimClient.API/NvimPlugin/Attributes/NvimFunctionAttribute.cs
@@ -5,6 +5,6 @@ namespace NvimClient.API.NvimPlugin.Attributes
   [AttributeUsage(AttributeTargets.Method)]
   public class NvimFunctionAttribute : Attribute
   {
-    public string Name  { get; set; }
+    public string Name { get; set; }
   }
 }

--- a/src/NvimClient.API/NvimPlugin/Attributes/NvimPluginAttribute.cs
+++ b/src/NvimClient.API/NvimPlugin/Attributes/NvimPluginAttribute.cs
@@ -5,10 +5,10 @@ namespace NvimClient.API.NvimPlugin.Attributes
   [AttributeUsage(AttributeTargets.Class)]
   public class NvimPluginAttribute : Attribute
   {
-    public string Name    { get; set; }
+    public string Name { get; set; }
     public string Version { get; set; }
     public string Website { get; set; }
     public string License { get; set; }
-    public string Logo    { get; set; }
+    public string Logo { get; set; }
   }
 }

--- a/src/NvimClient.API/NvimPlugin/NvimPluginAutoCommand.cs
+++ b/src/NvimClient.API/NvimPlugin/NvimPluginAutoCommand.cs
@@ -30,12 +30,12 @@ namespace NvimClient.API.NvimPlugin
       {
         argumentConverters.Add(
           nvimArg => evalParameterIndices.Zip(
-            (object[]) nvimArg, (index, arg) =>
-              new PluginArgument
-              {
-                Value = arg,
-                Index = index
-              })
+            (object[])nvimArg, (index, arg) =>
+             new PluginArgument
+             {
+               Value = arg,
+               Index = index
+             })
         );
       }
 

--- a/src/NvimClient.API/NvimPlugin/NvimPluginCommand.cs
+++ b/src/NvimClient.API/NvimPlugin/NvimPluginCommand.cs
@@ -94,7 +94,7 @@ namespace NvimClient.API.NvimPlugin
       {
         argumentConverters.Add(arg =>
         {
-          var range = ((object[]) arg).Cast<long>().ToArray();
+          var range = ((object[])arg).Cast<long>().ToArray();
           return new[]
           {
             new PluginArgument
@@ -149,12 +149,12 @@ namespace NvimClient.API.NvimPlugin
       {
         argumentConverters.Add(
           nvimArg => evalParameterIndices.Zip(
-            (object[]) nvimArg, (index, arg) =>
-              new PluginArgument
-              {
-                Value = arg,
-                Index = index
-              })
+            (object[])nvimArg, (index, arg) =>
+             new PluginArgument
+             {
+               Value = arg,
+               Index = index
+             })
         );
       }
 
@@ -162,11 +162,11 @@ namespace NvimClient.API.NvimPlugin
       Attribute = attribute;
     }
 
-    private int? BangParameterIndex     { get; set; }
-    private int? CountParameterIndex    { get; set; }
-    private int? RangeParameterIndex    { get; set; }
+    private int? BangParameterIndex { get; set; }
+    private int? CountParameterIndex { get; set; }
+    private int? RangeParameterIndex { get; set; }
     private int? RegisterParameterIndex { get; set; }
-    private NvimCommandAttribute Attribute              { get; }
+    private NvimCommandAttribute Attribute { get; }
 
     public override string HandlerName => $"{PluginPath}:command:{Name}";
 

--- a/src/NvimClient.API/NvimPlugin/NvimPluginExport.cs
+++ b/src/NvimClient.API/NvimPlugin/NvimPluginExport.cs
@@ -14,9 +14,9 @@ namespace NvimClient.API.NvimPlugin
     protected NvimPluginExport(string name, MethodInfo method,
       string pluginPath, object pluginInstance)
     {
-      Name           = name;
-      Method         = method;
-      PluginPath     = pluginPath;
+      Name = name;
+      Method = method;
+      PluginPath = pluginPath;
       PluginInstance = pluginInstance;
       Sync = method.GetCustomAttribute<AsyncStateMachineAttribute>() == null
              && method.ReturnType != typeof(Task)
@@ -31,12 +31,12 @@ namespace NvimClient.API.NvimPlugin
       set;
     }
 
-    internal        bool       Sync           { get; }
-    public abstract string     HandlerName    { get; }
-    protected       string     PluginPath     { get; }
-    private         object     PluginInstance { get; }
-    public          MethodInfo Method         { get; }
-    public          string     Name           { get; }
+    internal bool Sync { get; }
+    public abstract string HandlerName { get; }
+    protected string PluginPath { get; }
+    private object PluginInstance { get; }
+    public MethodInfo Method { get; }
+    public string Name { get; }
 
     public Func<object[], object> Handler =>
       args => Method.Invoke(PluginInstance,
@@ -83,8 +83,8 @@ namespace NvimClient.API.NvimPlugin
         .Select((param, index) =>
           new
           {
-            Index      = index,
-            Type       = param.ParameterType,
+            Index = index,
+            Type = param.ParameterType,
             Attributes = param.GetCustomAttributes()
           }))
       {
@@ -118,7 +118,7 @@ namespace NvimClient.API.NvimPlugin
 
     protected struct PluginArgument
     {
-      public int    Index { get; set; }
+      public int Index { get; set; }
       public object Value { get; set; }
     }
 

--- a/src/NvimClient.API/NvimPlugin/NvimPluginFunction.cs
+++ b/src/NvimClient.API/NvimPlugin/NvimPluginFunction.cs
@@ -50,7 +50,7 @@ namespace NvimClient.API.NvimPlugin
       {
         argumentConverters.Add(arg =>
         {
-          var range = ((object[]) arg).Cast<long>().ToArray();
+          var range = ((object[])arg).Cast<long>().ToArray();
           return new[]
           {
             new PluginArgument
@@ -70,12 +70,12 @@ namespace NvimClient.API.NvimPlugin
       {
         argumentConverters.Add(
           nvimArg => evalParameterIndices.Zip(
-            (object[]) nvimArg, (index, arg) =>
-              new PluginArgument
-              {
-                Value = arg,
-                Index = index
-              })
+            (object[])nvimArg, (index, arg) =>
+             new PluginArgument
+             {
+               Value = arg,
+               Index = index
+             })
         );
       }
 

--- a/src/NvimClient.API/NvimPlugin/Parameters/NvimRange.cs
+++ b/src/NvimClient.API/NvimPlugin/Parameters/NvimRange.cs
@@ -3,6 +3,6 @@ namespace NvimClient.API.NvimPlugin.Parameters
   public class NvimRange
   {
     public long FirstLine { get; set; }
-    public long LastLine  { get; set; }
+    public long LastLine { get; set; }
   }
 }

--- a/src/NvimClient.API/NvimPlugin/PluginHost.cs
+++ b/src/NvimClient.API/NvimPlugin/PluginHost.cs
@@ -62,7 +62,7 @@ namespace NvimClient.API.NvimPlugin
           {"logo", pluginAttribute.Logo}
         });
 
-      var channelID = (long) (await api.GetApiInfo())[0];
+      var channelID = (long)(await api.GetApiInfo())[0];
       await api.CallFunction("remote#host#Register",
         new object[]
         {

--- a/src/NvimClient.API/NvimUnhandledNotificationEventArgs.cs
+++ b/src/NvimClient.API/NvimUnhandledNotificationEventArgs.cs
@@ -8,10 +8,10 @@ namespace NvimClient.API
       object[] arguments)
     {
       MethodName = methodName;
-      Arguments  = arguments;
+      Arguments = arguments;
     }
 
-    public string   MethodName { get; }
-    public object[] Arguments  { get; }
+    public string MethodName { get; }
+    public object[] Arguments { get; }
   }
 }

--- a/src/NvimClient.API/NvimUnhandledRequestEventArgs.cs
+++ b/src/NvimClient.API/NvimUnhandledRequestEventArgs.cs
@@ -9,15 +9,15 @@ namespace NvimClient.API
     internal NvimUnhandledRequestEventArgs(NvimAPI nvim, uint requestId,
       string methodName, object[] arguments)
     {
-      _nvim      = nvim;
-      RequestId  = requestId;
+      _nvim = nvim;
+      RequestId = requestId;
       MethodName = methodName;
-      Arguments  = arguments;
+      Arguments = arguments;
     }
 
-    public string   MethodName { get; }
-    public object[] Arguments  { get; }
-    public uint     RequestId  { get; }
+    public string MethodName { get; }
+    public object[] Arguments { get; }
+    public uint RequestId { get; }
 
     public void SendResponse(object result, object error = null) =>
       _nvim.SendResponse(this, result, error);

--- a/src/NvimClient.API/UnixDomainSocketEndPoint.cs
+++ b/src/NvimClient.API/UnixDomainSocketEndPoint.cs
@@ -13,83 +13,83 @@ using System.Text;
 
 namespace NvimClient.API
 {
-    /// <summary>Represents a Unix Domain Socket endpoint as a path.</summary>
-    internal sealed class UnixDomainSocketEndPoint : EndPoint
+  /// <summary>Represents a Unix Domain Socket endpoint as a path.</summary>
+  internal sealed class UnixDomainSocketEndPoint : EndPoint
+  {
+    private const AddressFamily EndPointAddressFamily = AddressFamily.Unix;
+
+    private static readonly Encoding s_pathEncoding = Encoding.UTF8;
+    private static readonly int s_nativePathOffset = 2; // = offsetof(struct sockaddr_un, sun_path). It's the same on Linux and OSX
+    private static readonly int s_nativePathLength = 91; // sockaddr_un.sun_path at http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_un.h.html, -1 for terminator
+    private static readonly int s_nativeAddressSize = s_nativePathOffset + s_nativePathLength;
+
+    private readonly string _path;
+    private readonly byte[] _encodedPath;
+
+    public UnixDomainSocketEndPoint(string path)
     {
-        private const AddressFamily EndPointAddressFamily = AddressFamily.Unix;
+      if (path == null)
+      {
+        throw new ArgumentNullException(nameof(path));
+      }
 
-        private static readonly Encoding s_pathEncoding = Encoding.UTF8;
-        private static readonly int s_nativePathOffset = 2; // = offsetof(struct sockaddr_un, sun_path). It's the same on Linux and OSX
-        private static readonly int s_nativePathLength = 91; // sockaddr_un.sun_path at http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_un.h.html, -1 for terminator
-        private static readonly int s_nativeAddressSize = s_nativePathOffset + s_nativePathLength;
+      _path = path;
+      _encodedPath = s_pathEncoding.GetBytes(_path);
 
-        private readonly string _path;
-        private readonly byte[] _encodedPath;
+      if (path.Length == 0 || _encodedPath.Length > s_nativePathLength)
+      {
+        throw new ArgumentOutOfRangeException(nameof(path));
+      }
+    }
 
-        public UnixDomainSocketEndPoint(string path)
+    internal UnixDomainSocketEndPoint(SocketAddress socketAddress)
+    {
+      if (socketAddress == null)
+      {
+        throw new ArgumentNullException(nameof(socketAddress));
+      }
+
+      if (socketAddress.Family != EndPointAddressFamily ||
+          socketAddress.Size > s_nativeAddressSize)
+      {
+        throw new ArgumentOutOfRangeException(nameof(socketAddress));
+      }
+
+      if (socketAddress.Size > s_nativePathOffset)
+      {
+        _encodedPath = new byte[socketAddress.Size - s_nativePathOffset];
+        for (int i = 0; i < _encodedPath.Length; i++)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-
-            _path = path;
-            _encodedPath = s_pathEncoding.GetBytes(_path);
-
-            if (path.Length == 0 || _encodedPath.Length > s_nativePathLength)
-            {
-                throw new ArgumentOutOfRangeException(nameof(path));
-            }
+          _encodedPath[i] = socketAddress[s_nativePathOffset + i];
         }
 
-        internal UnixDomainSocketEndPoint(SocketAddress socketAddress)
-        {
-            if (socketAddress == null)
-            {
-                throw new ArgumentNullException(nameof(socketAddress));
-            }
+        _path = s_pathEncoding.GetString(_encodedPath, 0, _encodedPath.Length);
+      }
+      else
+      {
+        _encodedPath = new byte[0];
+        _path = string.Empty;
+      }
+    }
 
-            if (socketAddress.Family != EndPointAddressFamily ||
-                socketAddress.Size > s_nativeAddressSize)
-            {
-                throw new ArgumentOutOfRangeException(nameof(socketAddress));
-            }
+    public override SocketAddress Serialize()
+    {
+      var result = new SocketAddress(AddressFamily.Unix, s_nativeAddressSize);
+      Debug.Assert(_encodedPath.Length + s_nativePathOffset <= result.Size, "Expected path to fit in address");
 
-            if (socketAddress.Size > s_nativePathOffset)
-            {
-                _encodedPath = new byte[socketAddress.Size - s_nativePathOffset];
-                for (int i = 0; i < _encodedPath.Length; i++)
-                {
-                    _encodedPath[i] = socketAddress[s_nativePathOffset + i];
-                }
+      for (int index = 0; index < _encodedPath.Length; index++)
+      {
+        result[s_nativePathOffset + index] = _encodedPath[index];
+      }
+      result[s_nativePathOffset + _encodedPath.Length] = 0; // path must be null-terminated
 
-                _path = s_pathEncoding.GetString(_encodedPath, 0, _encodedPath.Length);
-            }
-            else
-            {
-                _encodedPath = new byte[0];
-                _path = string.Empty;
-            }
-        }
+      return result;
+    }
 
-        public override SocketAddress Serialize()
-        {
-            var result = new SocketAddress(AddressFamily.Unix, s_nativeAddressSize);
-            Debug.Assert(_encodedPath.Length + s_nativePathOffset <= result.Size, "Expected path to fit in address");
+    public override EndPoint Create(SocketAddress socketAddress) => new UnixDomainSocketEndPoint(socketAddress);
 
-            for (int index = 0; index < _encodedPath.Length; index++)
-            {
-                result[s_nativePathOffset + index] = _encodedPath[index];
-            }
-            result[s_nativePathOffset + _encodedPath.Length] = 0; // path must be null-terminated
+    public override AddressFamily AddressFamily => EndPointAddressFamily;
 
-            return result;
-        }
-
-        public override EndPoint Create(SocketAddress socketAddress) => new UnixDomainSocketEndPoint(socketAddress);
-
-        public override AddressFamily AddressFamily => EndPointAddressFamily;
-
-        public override string ToString() => _path;
-}
+    public override string ToString() => _path;
+  }
 }

--- a/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
+++ b/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
@@ -140,7 +140,8 @@ namespace NvimClient.API
   public class {eventName}EventArgs : EventArgs
   {{
 {
-      string.Join("", uiEvent.Parameters.Select(param => {
+      string.Join("", uiEvent.Parameters.Select(param =>
+      {
         var type = NvimTypesMap.GetCSharpType(param.Type);
         var paramName = StringUtil.ConvertToCamelCase(param.Name, true);
         return $"    public {type} {paramName} {{ get; set; }}\n";
@@ -233,7 +234,7 @@ namespace NvimClient.API
         Method = ""{function.Name}"",
         Arguments = GetRequestArguments(
           {string.Join(", ",
-            (isVirtualMethod ? new[] {"_msgPackExtObj"} : Enumerable.Empty<string>())
+            (isVirtualMethod ? new[] { "_msgPackExtObj" } : Enumerable.Empty<string>())
             .Concat(parameters.Select(param => param.Name)))})
       }});
 ";

--- a/src/NvimClient/EnumUtil.cs
+++ b/src/NvimClient/EnumUtil.cs
@@ -16,8 +16,8 @@ namespace NvimClient
     /// </returns>
     public static T GetAttribute<T>(Enum enumValue) where T : Attribute
     {
-      var type       = enumValue.GetType();
-      var valueName  = Enum.GetName(type, enumValue);
+      var type = enumValue.GetType();
+      var valueName = Enum.GetName(type, enumValue);
       var memberInfo = type.GetMember(valueName).First();
       return memberInfo.GetCustomAttribute<T>();
     }

--- a/src/NvimClient/NvimMsgpack/NvimMessageSerializer.cs
+++ b/src/NvimClient/NvimMsgpack/NvimMessageSerializer.cs
@@ -56,7 +56,7 @@ namespace NvimClient.NvimMsgpack
         throw new SerializationException($"Unknown message type (id {messageTypeId})");
       }
 
-      return (NvimMessage) OwnerContext.GetSerializer(messageType)
+      return (NvimMessage)OwnerContext.GetSerializer(messageType)
         .FromMessagePackObject(messagePackObject);
     }
   }

--- a/src/NvimClient/NvimProcess/NvimProcessStartInfo.cs
+++ b/src/NvimClient/NvimProcess/NvimProcessStartInfo.cs
@@ -85,9 +85,9 @@ namespace NvimClient.NvimProcess
       {
         CreateNoWindow = startOptions.HasFlag(StartOption.Headless) ||
                          startOptions.HasFlag(StartOption.Embed),
-        RedirectStandardInput  = redirectStandardIO,
+        RedirectStandardInput = redirectStandardIO,
         RedirectStandardOutput = redirectStandardIO,
-        RedirectStandardError  = redirectStandardIO
+        RedirectStandardError = redirectStandardIO
       };
     }
 

--- a/src/NvimClient/NvimProcess/StartOption.cs
+++ b/src/NvimClient/NvimProcess/StartOption.cs
@@ -5,9 +5,9 @@ namespace NvimClient.NvimProcess
   [Flags]
   public enum StartOption
   {
-                             None     = 0,
-    [Argument("--embed")]    Embed    = 1,
+    None = 0,
+    [Argument("--embed")] Embed = 1,
     [Argument("--headless")] Headless = 2,
-    [Argument("--api-info")] ApiInfo  = 4
+    [Argument("--api-info")] ApiInfo = 4
   }
 }

--- a/src/NvimClient/StringUtil.cs
+++ b/src/NvimClient/StringUtil.cs
@@ -20,7 +20,7 @@ namespace NvimClient
 
       var enumerator = str.GetEnumerator();
       enumerator.MoveNext();
-      var firstChar     = enumerator.Current;
+      var firstChar = enumerator.Current;
       var stringBuilder = new StringBuilder(str.Length * 2);
 
       AppendWithUnderscores(firstChar, false);
@@ -33,8 +33,8 @@ namespace NvimClient
           return;
         }
 
-        var currentChar       = enumerator.Current;
-        var currentCharUpper  = !char.IsLower(currentChar);
+        var currentChar = enumerator.Current;
+        var currentCharUpper = !char.IsLower(currentChar);
         var previousCharUpper = !char.IsLower(previousChar);
         if (currentCharUpper && !previousCharUpper)
         {
@@ -85,7 +85,7 @@ namespace NvimClient
         return str;
       }
 
-      var enumerator    = str.GetEnumerator();
+      var enumerator = str.GetEnumerator();
       var stringBuilder = new StringBuilder(str.Length);
 
       AppendFirstChar();
@@ -97,7 +97,7 @@ namespace NvimClient
           return;
         }
 
-        var currentChar  = enumerator.Current;
+        var currentChar = enumerator.Current;
         var isUnderscore = currentChar == '_';
         if (!isUnderscore)
         {
@@ -119,7 +119,7 @@ namespace NvimClient
           return;
         }
 
-        var currentChar  = enumerator.Current;
+        var currentChar = enumerator.Current;
         var isUnderscore = currentChar == '_';
         if (!isUnderscore)
         {

--- a/src/NvimPluginHost/AssemblyResolver.cs
+++ b/src/NvimPluginHost/AssemblyResolver.cs
@@ -14,8 +14,8 @@ namespace NvimPluginHost
   internal sealed class AssemblyResolver : IDisposable
   {
     private readonly ICompilationAssemblyResolver _assemblyResolver;
-    private readonly DependencyContext            _dependencyContext;
-    private readonly AssemblyLoadContext          _loadContext;
+    private readonly DependencyContext _dependencyContext;
+    private readonly AssemblyLoadContext _loadContext;
 
     public AssemblyResolver(string path)
     {
@@ -31,7 +31,7 @@ namespace NvimPluginHost
          new PackageCompilationAssemblyResolver()
        });
 
-      _loadContext           =  AssemblyLoadContext.GetLoadContext(Assembly);
+      _loadContext = AssemblyLoadContext.GetLoadContext(Assembly);
       _loadContext.Resolving += OnResolving;
     }
 

--- a/src/NvimPluginHost/Log.cs
+++ b/src/NvimPluginHost/Log.cs
@@ -12,7 +12,7 @@ namespace NvimPluginHost
       var logFile = Environment.GetEnvironmentVariable("NVIM_DOTNET_LOG_FILE");
       if (logFile != null)
       {
-        _writer = new StreamWriter(logFile, true) {AutoFlush = true};
+        _writer = new StreamWriter(logFile, true) { AutoFlush = true };
       }
     }
 

--- a/src/NvimPluginHost/Program.cs
+++ b/src/NvimPluginHost/Program.cs
@@ -60,8 +60,8 @@ namespace NvimPluginHost
       nvim.RegisterHandler("poll", args => "ok");
       nvim.RegisterHandler("specs", args =>
       {
-        var slnFilePath = (string) args.First();
-        var pluginType  = GetPluginFromSolutionPath(slnFilePath);
+        var slnFilePath = (string)args.First();
+        var pluginType = GetPluginFromSolutionPath(slnFilePath);
         return pluginType == null
           ? null
           : PluginHost.GetPluginSpecs(pluginType);
@@ -98,8 +98,8 @@ namespace NvimPluginHost
       var buildProcess = Process.Start(
         new ProcessStartInfo
         {
-          FileName       = "dotnet",
-          Arguments      = "build " + slnFileInfo.FullName,
+          FileName = "dotnet",
+          Arguments = "build " + slnFileInfo.FullName,
           CreateNoWindow = true
         });
       buildProcess?.WaitForExit();

--- a/test/NvimClient.Test/NvimTests.cs
+++ b/test/NvimClient.Test/NvimTests.cs
@@ -52,7 +52,7 @@ namespace NvimClient.Test
       var context = new SerializationContext();
       context.DictionarySerlaizationOptions.KeyTransformer =
         StringUtil.ConvertToSnakeCase;
-      var serializer  = context.GetSerializer<NvimAPIMetadata>();
+      var serializer = context.GetSerializer<NvimAPIMetadata>();
       var apiMetadata = serializer.Unpack(process.StandardOutput.BaseStream);
 
       Assert.IsNotNull(apiMetadata.Version);
@@ -76,12 +76,12 @@ namespace NvimClient.Test
       var request = new NvimRequest
       {
         MessageId = 42,
-        Method    = "nvim_eval",
-        Arguments = new MessagePackObject(new MessagePackObject[] {$"'{testString}'"})
+        Method = "nvim_eval",
+        Arguments = new MessagePackObject(new MessagePackObject[] { $"'{testString}'" })
       };
       serializer.Pack(process.StandardInput.BaseStream, request);
 
-      var response = (NvimResponse) serializer.Unpack(process.StandardOutput.BaseStream);
+      var response = (NvimResponse)serializer.Unpack(process.StandardOutput.BaseStream);
 
       Assert.IsTrue(response.MessageId == request.MessageId
                     && response.Error == MessagePackObject.Nil
@@ -118,15 +118,15 @@ namespace NvimClient.Test
       var api = new NvimAPI();
       api.RegisterHandler("client-call", args =>
       {
-        CollectionAssert.AreEqual(new[] {1L, 2L, 3L}, args);
-        return new[]{4, 5, 6};
+        CollectionAssert.AreEqual(new[] { 1L, 2L, 3L }, args);
+        return new[] { 4, 5, 6 };
       });
       var objects = await api.GetApiInfo();
-      var channelID = (long) objects.First();
+      var channelID = (long)objects.First();
       await api.Command(
         $"let g:result = rpcrequest({channelID}, 'client-call', 1, 2, 3)");
-      var result = (object[]) await api.GetVar("result");
-      CollectionAssert.AreEqual(new[]{4L, 5L, 6L}, result);
+      var result = (object[])await api.GetVar("result");
+      CollectionAssert.AreEqual(new[] { 4L, 5L, 6L }, result);
     }
 
     [TestMethod]
@@ -160,7 +160,7 @@ namespace NvimClient.Test
       Assert.AreEqual(3L, result);
 
       await api.Command($"{nameof(TestPlugin.TestCommand1)} a b c");
-      CollectionAssert.AreEqual(new[] {"a", "b", "c"}, TestPlugin.Command1Args);
+      CollectionAssert.AreEqual(new[] { "a", "b", "c" }, TestPlugin.Command1Args);
 
       await api.Command($"{nameof(TestPlugin.TestCommand2)} 1 2 3");
       Assert.AreEqual("1 2 3", TestPlugin.Command2Args);
@@ -176,8 +176,8 @@ namespace NvimClient.Test
     public async Task TestTCPSocket()
     {
       var nvimStdio = new NvimAPI();
-      var serverAddress = (string) await nvimStdio.CallFunction("serverstart",
-        new object[] {System.Net.IPAddress.Loopback + ":"});
+      var serverAddress = (string)await nvimStdio.CallFunction("serverstart",
+        new object[] { System.Net.IPAddress.Loopback + ":" });
 
       var nvimTCPSocket = new NvimAPI(serverAddress);
       Assert.IsNotNull(await nvimTCPSocket.CommandOutput("version"));
@@ -188,26 +188,26 @@ namespace NvimClient.Test
     {
       var nvimStdio = new NvimAPI();
       var serverAddress =
-        (string) await nvimStdio.CallFunction("serverstart", new object[0]);
+        (string)await nvimStdio.CallFunction("serverstart", new object[0]);
 
       var nvimLocalSocket = new NvimAPI(serverAddress);
       Assert.IsNotNull(await nvimLocalSocket.CommandOutput("version"));
     }
 
     [DataTestMethod]
-    [DataRow(typeof(bool),                          true)]
-    [DataRow(typeof(Boolean),                       true)]
-    [DataRow(typeof(int),                           false)]
-    [DataRow(typeof(Int32),                         false)]
-    [DataRow(typeof(long),                          true)]
-    [DataRow(typeof(Int64),                         true)]
-    [DataRow(typeof(object[]),                      true)]
-    [DataRow(typeof(long[]),                        true)]
-    [DataRow(typeof(int[]),                         false)]
-    [DataRow(typeof(IDictionary<object, object>),   true)]
-    [DataRow(typeof(IDictionary<long, string>),     true)]
+    [DataRow(typeof(bool), true)]
+    [DataRow(typeof(Boolean), true)]
+    [DataRow(typeof(int), false)]
+    [DataRow(typeof(Int32), false)]
+    [DataRow(typeof(long), true)]
+    [DataRow(typeof(Int64), true)]
+    [DataRow(typeof(object[]), true)]
+    [DataRow(typeof(long[]), true)]
+    [DataRow(typeof(int[]), false)]
+    [DataRow(typeof(IDictionary<object, object>), true)]
+    [DataRow(typeof(IDictionary<long, string>), true)]
     [DataRow(typeof(IDictionary<string, DateTime>), false)]
-    [DataRow(typeof(IDictionary<Random, long>),     false)]
+    [DataRow(typeof(IDictionary<Random, long>), false)]
     public void TestNvimTypeValidation(Type type, bool shouldBeValid)
     {
       Assert.AreEqual(shouldBeValid, NvimTypesMap.IsValidType(type));

--- a/test/NvimClient.Test/TestPlugin.cs
+++ b/test/NvimClient.Test/TestPlugin.cs
@@ -44,7 +44,7 @@ namespace NvimClient.Test
     public void OnBufEnter([NvimEval("expand('<afile>')")] string filename,
       [NvimEval("&shiftwidth")] long shiftWidth)
     {
-      var indent = new string(' ', (int) shiftWidth);
+      var indent = new string(' ', (int)shiftWidth);
       _nvim.SetCurrentLine(
         indent + $"{nameof(OnBufEnter)} called with {filename}");
       AutocmdCalled = true;


### PR DESCRIPTION
Formats the codebase with [dotnet-format](https://github.com/dotnet/format).

Note that this *is* the official formatter for .NET 6, as it's builtin to the SDK (see the pinned issue in the linked repo above), but until that's released it has to be installed via [the Nuget package](https://www.nuget.org/packages/dotnet-format/).