### PR TITLE
fix(NvimPluginHost): prevent crash when running dotnet build

### DIFF
--- a/src/NvimPluginHost/Program.cs
+++ b/src/NvimPluginHost/Program.cs
@@ -100,7 +100,9 @@ namespace NvimPluginHost
         {
           FileName = "dotnet",
           Arguments = "build " + slnFileInfo.FullName,
-          CreateNoWindow = true
+          CreateNoWindow = true,
+          RedirectStandardError = true,
+          RedirectStandardOutput = true,
         });
       buildProcess?.WaitForExit();
 


### PR DESCRIPTION
This PR fixes a crash in NvimPluginHost that occurred when running the
dotnet build process. The program previously stopped because
StandardOutput was accessed without being redirected.

Changes:
- Enable RedirectStandardOutput and RedirectStandardError in ProcessStartInfo
- Prevents crash/failure to run
- Ensures build logs and error messages are captured programmatically
