### PR TITLE
build: migrate to .NET 8 and unify DocumentationFile output path

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/NvimClient.API/NvimClient.API.csproj
+++ b/src/NvimClient.API/NvimClient.API.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <DocumentationFile>bin\Debug\net5.0\NvimClient.API.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
     <RepositoryUrl>https://github.com/neovim/nvim.net</RepositoryUrl>
     <Version>0.20.0</Version>
   </PropertyGroup>

--- a/src/NvimClient.APIGenerator/NvimClient.APIGenerator.csproj
+++ b/src/NvimClient.APIGenerator/NvimClient.APIGenerator.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NvimClient/NvimClient.csproj
+++ b/src/NvimClient/NvimClient.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="MsgPack.Cli" Version="0.9.2" />
   </ItemGroup>

--- a/src/NvimPluginHost/NvimPluginHost.csproj
+++ b/src/NvimPluginHost/NvimPluginHost.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NvimClient.Test/NvimClient.Test.csproj
+++ b/test/NvimClient.Test/NvimClient.Test.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR updates the project to .NET 8 and normalizes the XML
documentation file output paths.

Changes:
- Centralize TargetFramework in Directory.Build.props (net8.0)
- Remove per-project net5.0 settings
- Use $(Configuration) and $(TargetFramework) in DocumentationFile to
  generate consistent XML doc output
