### PR TITLE
ci(github): update setup-dotnet to 8.0.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1.8.1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 8.0.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 8.0.x
 
     - name: Restore dependencies
       run: dotnet restore


### PR DESCRIPTION
Updates the GitHub Actions workflows to target .NET 8.0.x instead of 5.0.x.

- publish.yml: setup-dotnet -> 8.0.x
- test.yml:    setup-dotnet -> 8.0.x

This aligns CI with the project’s .NET 8 configuration.
