### PR TITLE
fix: support Neovim 0.12.2 generation

### DIFF
--- a/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
+++ b/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
@@ -37,8 +37,13 @@ namespace NvimClient
     public static void GenerateCSharpFile(string outputPath,
       IEnumerable<FunctionDoc> functionDocs)
     {
-      _functionDocs = functionDocs?.ToDictionary(functionDoc => functionDoc.Function,
-        funcDoc => funcDoc);
+      _functionDocs = functionDocs
+        .GroupBy(x => x.Function)
+        .ToDictionary(
+          functionDoc => functionDoc.Key,
+          funcDoc => funcDoc.First()
+        );
+
       var apiMetadata = GetAPIMetadata();
 
       // Filter out functions only callable from Lua.

--- a/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
+++ b/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
@@ -288,8 +288,11 @@ namespace NvimClient.API
           yield return "</para>";
           yield break;
         case InlineCode inlineCode:
-          yield return
-            $"<c>${SecurityElement.Escape(inlineCode.ToString())}</c>";
+          foreach (var line in EscapeDocLines(inlineCode.ToString()))
+          {
+            yield return $"<c>{line}</c>";
+          }
+
           yield break;
         case DocList list:
           yield return
@@ -310,10 +313,20 @@ namespace NvimClient.API
           yield return "</list>";
           yield break;
         default:
-          yield return SecurityElement.Escape(element.ToString());
+          foreach (var line in EscapeDocLines(element.ToString()))
+          {
+            yield return line;
+          }
+
           yield break;
       }
     }
+
+    private static IEnumerable<string> EscapeDocLines(string text) =>
+      (SecurityElement.Escape(text) ?? string.Empty)
+      .Replace("\r\n", "\n")
+      .Replace('\r', '\n')
+      .Split('\n');
 
     private static string
       GenerateNvimTypeCases(Dictionary<string, NvimType> apiMetadata) =>

--- a/src/NvimClient/NvimMsgpack/NvimTypesMap.cs
+++ b/src/NvimClient/NvimMsgpack/NvimTypesMap.cs
@@ -13,6 +13,7 @@ namespace NvimClient.NvimMsgpack
       {
         ("Array",           "object[]",            typeof(object[])),
         ("Boolean",         "bool",                typeof(bool)),
+        ("Dict",            "IDictionary",         typeof(IDictionary)),
         ("Dictionary",      "IDictionary",         typeof(IDictionary)),
         ("Float",           "double",              typeof(double)),
         ("Integer",         "long",                typeof(long)),
@@ -51,6 +52,20 @@ namespace NvimClient.NvimMsgpack
         var valueType =
           GetCSharpType(dictionaryRegexMatch.Groups["ValueType"].Value);
         return $"IDictionary<{keyType}, {valueType}>";
+      }
+
+      var dictOfRegexMatch = Regex.Match(nvimType,
+        @"^DictOf\((?<ValueType>.+)\)$");
+      if (dictOfRegexMatch.Success)
+      {
+        return "IDictionary";
+      }
+
+      var keyDictRegexMatch = Regex.Match(nvimType,
+        @"^Dict(?:As)?\(.+\)$");
+      if (keyDictRegexMatch.Success)
+      {
+        return "IDictionary";
       }
 
       return "Nvim" + nvimType;

--- a/test/NvimClient.Test/NvimTests.cs
+++ b/test/NvimClient.Test/NvimTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -213,6 +214,7 @@ namespace NvimClient.Test
     [DataRow(typeof(object[]), true)]
     [DataRow(typeof(long[]), true)]
     [DataRow(typeof(int[]), false)]
+    [DataRow(typeof(IDictionary), true)]
     [DataRow(typeof(IDictionary<object, object>), true)]
     [DataRow(typeof(IDictionary<long, string>), true)]
     [DataRow(typeof(IDictionary<string, DateTime>), false)]
@@ -225,6 +227,10 @@ namespace NvimClient.Test
     [DataTestMethod]
     [DataRow("Boolean", "bool")]
     [DataRow("Array", "object[]")]
+    [DataRow("Dict", "IDictionary")]
+    [DataRow("DictAs(get_mode)", "IDictionary")]
+    [DataRow("DictOf(Integer)", "IDictionary")]
+    [DataRow("Dict(win_config)", "IDictionary")]
     [DataRow("Dictionary", "IDictionary")]
     [DataRow("ArrayOf(Float)", "double[]")]
     [DataRow("ArrayOf(Integer, 2)", "long[]")]


### PR DESCRIPTION
Updates the generator for Neovim 0.12.2 API metadata and fixes multiline XML docs output.

## Blocked by

- #25