### PR TITLE
style: format with CSharpier

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,30 @@
+name: Formatting
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  format:
+    name: Check formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install CSharpier
+        run: dotnet tool install --tool-path ./.tools CSharpier --version 1.2.6
+
+      - name: Check formatting
+        run: |
+          mapfile -t files < <(git ls-files '*.cs' '*.csx' '*.csproj' '*.props' '*.targets' '*.xml' '*.slnx')
+          ./.tools/csharpier check "${files[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+## Formatting
+
+Format C# files, XML project/configuration files, and `.slnx` files with
+CSharpier before opening a pull request.
+
+Install CSharpier as a local .NET tool:
+
+```sh
+dotnet tool install --global CSharpier
+```
+
+Format the checked files locally:
+
+```sh
+dotnet csharpier format $(git ls-files '*.cs' '*.csx' '*.csproj' '*.props' '*.targets' '*.xml' '*.slnx')
+```
+
+Check formatting without writing changes:
+
+```sh
+dotnet csharpier check $(git ls-files '*.cs' '*.csx' '*.csproj' '*.props' '*.targets' '*.xml' '*.slnx')
+```
+
+See the official CSharpier docs for
+[installation](https://csharpier.com/docs/About) and
+[editor integration](https://csharpier.com/docs/Editors), including format on
+save.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="CSharpier.Core" Version="1.2.6" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageVersion Include="MsgPack.Cli" Version="0.9.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CSharpier.Core" Version="1.2.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+    <PackageVersion
+      Include="Microsoft.Extensions.DependencyModel"
+      Version="2.1.0"
+    />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageVersion Include="MsgPack.Cli" Version="0.9.2" />
     <PackageVersion Include="MSTest.TestAdapter" Version="1.3.0" />

--- a/src/NvimClient.API/NvimAPI.cs
+++ b/src/NvimClient.API/NvimAPI.cs
@@ -22,15 +22,16 @@ namespace NvimClient.API
   public partial class NvimAPI
   {
     public event EventHandler<NvimUnhandledRequestEventArgs> OnUnhandledRequest;
-    public event EventHandler<NvimUnhandledNotificationEventArgs>
-      OnUnhandledNotification;
+    public event EventHandler<NvimUnhandledNotificationEventArgs> OnUnhandledNotification;
 
     private readonly Stream _inputStream;
     private readonly Stream _outputStream;
     private readonly MessagePackSerializer<NvimMessage> _serializer;
     private readonly BlockingCollection<NvimMessage> _messageQueue;
-    private readonly ConcurrentDictionary<long, PendingRequest>
-      _pendingRequests;
+    private readonly ConcurrentDictionary<
+      long,
+      PendingRequest
+    > _pendingRequests;
     private delegate void NvimHandler(uint? requestId, object[] arguments);
     private readonly ConcurrentDictionary<string, NvimHandler> _handlers;
     private uint _messageIdCounter;
@@ -40,37 +41,42 @@ namespace NvimClient.API
     /// Starts a new Nvim process and communicates
     /// with it through stdin and stdout streams.
     /// </summary>
-    public NvimAPI() : this(Process.Start(
-        new NvimProcessStartInfo(StartOption.Embed | StartOption.Headless)))
-    {
-    }
+    public NvimAPI()
+      : this(
+        Process.Start(
+          new NvimProcessStartInfo(StartOption.Embed | StartOption.Headless)
+        )
+      ) { }
 
     /// <summary>
     /// Communicates with an already-running Nvim
     /// process through its stdin and stdout streams.
     /// </summary>
     /// <param name="process"></param>
-    public NvimAPI(Process process) : this(process.StandardInput.BaseStream,
-      process.StandardOutput.BaseStream)
-    {
-    }
+    public NvimAPI(Process process)
+      : this(
+        process.StandardInput.BaseStream,
+        process.StandardOutput.BaseStream
+      ) { }
 
     /// <summary>
     /// Communicates with Nvim through the specified server address.
     /// </summary>
     /// <param name="serverAddress"></param>
-    public NvimAPI(string serverAddress) : this(
-      GetStreamFromServerAddress(serverAddress))
-    {
-    }
+    public NvimAPI(string serverAddress)
+      : this(GetStreamFromServerAddress(serverAddress)) { }
 
     private static Stream GetStreamFromServerAddress(string serverAddress)
     {
       var lastColonIndex = serverAddress.LastIndexOf(':');
-      if (lastColonIndex != -1 && lastColonIndex != 0
-                               && int.TryParse(
-                                    serverAddress.Substring(lastColonIndex + 1),
-                                    out var port))
+      if (
+        lastColonIndex != -1
+        && lastColonIndex != 0
+        && int.TryParse(
+          serverAddress.Substring(lastColonIndex + 1),
+          out var port
+        )
+      )
       {
         // TCP socket
         var tcpClient = new TcpClient();
@@ -83,19 +89,28 @@ namespace NvimClient.API
       if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
       {
         // Named Pipe on Windows
-        var match = Regex.Match(serverAddress,
-          @"\\\\(?'serverName'[^\\]+)\\pipe\\(?'pipeName'[^\\]+)");
+        var match = Regex.Match(
+          serverAddress,
+          @"\\\\(?'serverName'[^\\]+)\\pipe\\(?'pipeName'[^\\]+)"
+        );
         var serverName = match.Groups["serverName"].Value;
         var pipeName = match.Groups["pipeName"].Value;
-        var pipeStream = new NamedPipeClientStream(serverName, pipeName,
-          PipeDirection.InOut, PipeOptions.Asynchronous);
+        var pipeStream = new NamedPipeClientStream(
+          serverName,
+          pipeName,
+          PipeDirection.InOut,
+          PipeOptions.Asynchronous
+        );
         pipeStream.Connect();
         return pipeStream;
       }
 
       // Unix Domain Socket on other OSes
-      var unixDomainSocket = new Socket(AddressFamily.Unix,
-        SocketType.Stream, ProtocolType.Unspecified);
+      var unixDomainSocket = new Socket(
+        AddressFamily.Unix,
+        SocketType.Stream,
+        ProtocolType.Unspecified
+      );
       unixDomainSocket.Connect(new UnixDomainSocketEndPoint(serverAddress));
       return new NetworkStream(unixDomainSocket, true);
     }
@@ -104,10 +119,8 @@ namespace NvimClient.API
     /// Communicates with Nvim through the provided stream.
     /// </summary>
     /// <param name="inputOutputStream">The stream to use.</param>
-    public NvimAPI(Stream inputOutputStream) : this(inputOutputStream,
-      inputOutputStream)
-    {
-    }
+    public NvimAPI(Stream inputOutputStream)
+      : this(inputOutputStream, inputOutputStream) { }
 
     /// <summary>
     /// Communicates with Nvim through the
@@ -136,11 +149,32 @@ namespace NvimClient.API
     public void RegisterHandler(string name, Action<object[]> handler) =>
       RegisterHandler(name, (Delegate)handler);
 
-    public void RegisterHandler(string name,
-      Func<object[], Task<object>> handler) => RegisterHandler(name,
-      (requestId, args) =>
-      {
-        Task.Run(() =>
+    public void RegisterHandler(
+      string name,
+      Func<object[], Task<object>> handler
+    ) =>
+      RegisterHandler(
+        name,
+        (requestId, args) =>
+        {
+          Task.Run(() =>
+          {
+            if (requestId.HasValue)
+            {
+              CallHandlerAndSendResponse(requestId.Value, handler, args);
+            }
+            else
+            {
+              handler(args);
+            }
+          });
+        }
+      );
+
+    private void RegisterHandler(string name, Delegate handler) =>
+      RegisterHandler(
+        name,
+        (requestId, args) =>
         {
           if (requestId.HasValue)
           {
@@ -148,35 +182,24 @@ namespace NvimClient.API
           }
           else
           {
-            handler(args);
+            handler.DynamicInvoke(args);
           }
-        });
-      });
-
-    private void RegisterHandler(string name, Delegate handler) =>
-      RegisterHandler(name, (requestId, args) =>
-      {
-        if (requestId.HasValue)
-        {
-          CallHandlerAndSendResponse(requestId.Value, handler, args);
         }
-        else
-        {
-          handler.DynamicInvoke(args);
-        }
-      });
+      );
 
     private void RegisterHandler(string name, NvimHandler handler)
     {
       if (!_handlers.TryAdd(name, handler))
       {
-        throw new Exception(
-          $"Handler for \"{name}\" is already registered");
+        throw new Exception($"Handler for \"{name}\" is already registered");
       }
     }
 
-    private void CallHandlerAndSendResponse(uint requestId, Delegate handler,
-      object[] args)
+    private void CallHandlerAndSendResponse(
+      uint requestId,
+      Delegate handler,
+      object[] args
+    )
     {
       var response = new NvimResponse { MessageId = requestId };
       try
@@ -192,15 +215,17 @@ namespace NvimClient.API
       _messageQueue.Add(response);
     }
 
-
-    internal void SendResponse(NvimUnhandledRequestEventArgs args, object result,
-      object error)
+    internal void SendResponse(
+      NvimUnhandledRequestEventArgs args,
+      object result,
+      object error
+    )
     {
       var response = new NvimResponse
       {
         MessageId = args.RequestId,
         Result = ConvertToMessagePackObject(result),
-        Error = ConvertToMessagePackObject(error)
+        Error = ConvertToMessagePackObject(error),
       };
       _messageQueue.Add(response);
     }
@@ -226,7 +251,8 @@ namespace NvimClient.API
             var objectArray = (object[])result;
             var resultArray = Array.CreateInstance(
               typeof(TResult).GetElementType(),
-              objectArray.Length);
+              objectArray.Length
+            );
             Array.Copy(objectArray, resultArray, resultArray.Length);
             return (TResult)(object)resultArray;
           }
@@ -238,12 +264,13 @@ namespace NvimClient.API
     private void StartSendLoop()
     {
       Task.Run(async () =>
-      {
-        foreach (var request in _messageQueue.GetConsumingEnumerable())
         {
-          await _serializer.PackAsync(_inputStream, request);
-        }
-      }).ContinueWith(t => _waitEvent.Set());
+          foreach (var request in _messageQueue.GetConsumingEnumerable())
+          {
+            await _serializer.PackAsync(_inputStream, request);
+          }
+        })
+        .ContinueWith(t => _waitEvent.Set());
     }
 
     private void StartReceiveLoop()
@@ -256,7 +283,6 @@ namespace NvimClient.API
         try
         {
           message = await _serializer.UnpackAsync(_outputStream);
-
         }
         catch
         {
@@ -267,70 +293,91 @@ namespace NvimClient.API
         switch (message)
         {
           case NvimNotification notification:
+          {
+            if (notification.Method == "redraw")
             {
-              if (notification.Method == "redraw")
-              {
-                var uiEvents = notification.Arguments.AsEnumerable().SelectMany(
-                  uiEvent =>
-                  {
-                    var data = uiEvent.AsList();
-                    var name = data.First().AsString();
-                    return data.Select(args => new { Name = name, Args = args })
-                               .Skip(1);
-                  });
-                foreach (var uiEvent in uiEvents)
+              var uiEvents = notification
+                .Arguments.AsEnumerable()
+                .SelectMany(uiEvent =>
                 {
-                  CallUIEventHandler(uiEvent.Name,
-                    (object[])ConvertFromMessagePackObject(uiEvent.Args));
-                }
-              }
-
-              var arguments =
-                (object[])ConvertFromMessagePackObject(notification.Arguments);
-              if (_handlers.TryGetValue(notification.Method, out var handler))
+                  var data = uiEvent.AsList();
+                  var name = data.First().AsString();
+                  return data.Select(args => new { Name = name, Args = args })
+                    .Skip(1);
+                });
+              foreach (var uiEvent in uiEvents)
               {
-                handler(null, arguments);
+                CallUIEventHandler(
+                  uiEvent.Name,
+                  (object[])ConvertFromMessagePackObject(uiEvent.Args)
+                );
               }
-              else
-              {
-                OnUnhandledNotification?.Invoke(this,
-                  new NvimUnhandledNotificationEventArgs(notification.Method,
-                    arguments));
-              }
-
-              break;
             }
-          case NvimRequest request:
+
+            var arguments = (object[])ConvertFromMessagePackObject(
+              notification.Arguments
+            );
+            if (_handlers.TryGetValue(notification.Method, out var handler))
             {
-              var arguments =
-                (object[])ConvertFromMessagePackObject(request.Arguments);
-              if (_handlers.TryGetValue(request.Method, out var handler))
-              {
-                handler(request.MessageId, arguments);
-              }
-              else
-              {
-                OnUnhandledRequest?.Invoke(this,
-                  new NvimUnhandledRequestEventArgs(this, request.MessageId,
-                    request.Method, arguments));
-              }
-
-              break;
+              handler(null, arguments);
             }
+            else
+            {
+              OnUnhandledNotification?.Invoke(
+                this,
+                new NvimUnhandledNotificationEventArgs(
+                  notification.Method,
+                  arguments
+                )
+              );
+            }
+
+            break;
+          }
+          case NvimRequest request:
+          {
+            var arguments = (object[])ConvertFromMessagePackObject(
+              request.Arguments
+            );
+            if (_handlers.TryGetValue(request.Method, out var handler))
+            {
+              handler(request.MessageId, arguments);
+            }
+            else
+            {
+              OnUnhandledRequest?.Invoke(
+                this,
+                new NvimUnhandledRequestEventArgs(
+                  this,
+                  request.MessageId,
+                  request.Method,
+                  arguments
+                )
+              );
+            }
+
+            break;
+          }
           case NvimResponse response:
-            if (!_pendingRequests.TryRemove(response.MessageId,
-              out var pendingRequest))
+            if (
+              !_pendingRequests.TryRemove(
+                response.MessageId,
+                out var pendingRequest
+              )
+            )
             {
               throw new Exception(
                 "Received response with "
-                + $"unknown message ID \"{response.MessageId}\"");
+                  + $"unknown message ID \"{response.MessageId}\""
+              );
             }
 
             pendingRequest.Complete(response);
             break;
           default:
             throw new TypeLoadException(
-              $"Unknown message type \"{message.GetType()}\"");
+              $"Unknown message type \"{message.GetType()}\""
+            );
         }
 
         Receive();
@@ -353,23 +400,30 @@ namespace NvimClient.API
         var taskCompletionSource = new TaskCompletionSource<NvimResponse>();
 
         void RegisterResponseEvent(TimeSpan timeout) =>
-          ThreadPool.RegisterWaitForSingleObject(_receivedResponseEvent,
+          ThreadPool.RegisterWaitForSingleObject(
+            _receivedResponseEvent,
             (state, timedOut) =>
             {
               if (timedOut)
               {
-                Debug.WriteLine("Warning: response was not received "
-                                + $"within {timeout.TotalSeconds} seconds");
+                Debug.WriteLine(
+                  "Warning: response was not received "
+                    + $"within {timeout.TotalSeconds} seconds"
+                );
                 // Continue waiting without a timeout
                 RegisterResponseEvent(Timeout.InfiniteTimeSpan);
               }
               else
               {
                 taskCompletionSource.SetResult(
-                  ((PendingRequest)state)._response);
+                  ((PendingRequest)state)._response
+                );
               }
             },
-            this, timeout, true);
+            this,
+            timeout,
+            true
+          );
 
         RegisterResponseEvent(_responseTimeout);
 
@@ -397,7 +451,9 @@ namespace NvimClient.API
 
       if (msgPackObject.IsArray)
       {
-        return msgPackObject.AsEnumerable().Select(ConvertFromMessagePackObject)
+        return msgPackObject
+          .AsEnumerable()
+          .Select(ConvertFromMessagePackObject)
           .ToArray();
       }
 
@@ -406,7 +462,8 @@ namespace NvimClient.API
         var msgPackDictionary = msgPackObject.AsDictionary();
         return msgPackDictionary.ToDictionary(
           keyValuePair => ConvertFromMessagePackObject(keyValuePair.Key),
-          keyValuePair => ConvertFromMessagePackObject(keyValuePair.Value));
+          keyValuePair => ConvertFromMessagePackObject(keyValuePair.Value)
+        );
       }
 
       var obj = msgPackObject.ToObject();
@@ -420,9 +477,9 @@ namespace NvimClient.API
 
     private static MessagePackObject ConvertToMessagePackObject(object obj)
     {
-      IEnumerable<MessagePackObject>
-      ConvertEnumerable(IEnumerable enumerable) =>
-        enumerable.Cast<object>().Select(ConvertToMessagePackObject);
+      IEnumerable<MessagePackObject> ConvertEnumerable(
+        IEnumerable enumerable
+      ) => enumerable.Cast<object>().Select(ConvertToMessagePackObject);
 
       if (obj is Array array)
       {
@@ -432,8 +489,11 @@ namespace NvimClient.API
       if (obj is IDictionary dictionary)
       {
         var msgPackDictionary = new MessagePackObjectDictionary();
-        var keysAndValues = ConvertEnumerable(dictionary.Keys).Zip(
-          ConvertEnumerable(dictionary.Values), (key, value) => (key, value));
+        var keysAndValues = ConvertEnumerable(dictionary.Keys)
+          .Zip(
+            ConvertEnumerable(dictionary.Values),
+            (key, value) => (key, value)
+          );
         foreach (var (key, value) in keysAndValues)
         {
           msgPackDictionary.Add(key, value);
@@ -446,7 +506,7 @@ namespace NvimClient.API
     }
 
     private static MessagePackObject GetRequestArguments(
-      params object[] parameters) =>
-      ConvertToMessagePackObject(parameters);
+      params object[] parameters
+    ) => ConvertToMessagePackObject(parameters);
   }
 }

--- a/src/NvimClient.API/NvimAPI.generated.cs
+++ b/src/NvimClient.API/NvimAPI.generated.cs
@@ -1,4064 +1,5005 @@
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 using MsgPack;
 using NvimClient.NvimMsgpack.Models;
 
 namespace NvimClient.API
 {
-  public partial class NvimAPI
-  {
-    public event EventHandler<ModeInfoSetEventArgs> ModeInfoSetEvent;
-    public event EventHandler UpdateMenuEvent;
-    public event EventHandler BusyStartEvent;
-    public event EventHandler BusyStopEvent;
-    public event EventHandler MouseOnEvent;
-    public event EventHandler MouseOffEvent;
-    public event EventHandler<ModeChangeEventArgs> ModeChangeEvent;
-    public event EventHandler BellEvent;
-    public event EventHandler VisualBellEvent;
-    public event EventHandler FlushEvent;
-    public event EventHandler SuspendEvent;
-    public event EventHandler<SetTitleEventArgs> SetTitleEvent;
-    public event EventHandler<SetIconEventArgs> SetIconEvent;
-    public event EventHandler<ScreenshotEventArgs> ScreenshotEvent;
-    public event EventHandler<OptionSetEventArgs> OptionSetEvent;
-    public event EventHandler<UpdateFgEventArgs> UpdateFgEvent;
-    public event EventHandler<UpdateBgEventArgs> UpdateBgEvent;
-    public event EventHandler<UpdateSpEventArgs> UpdateSpEvent;
-    public event EventHandler<ResizeEventArgs> ResizeEvent;
-    public event EventHandler ClearEvent;
-    public event EventHandler EolClearEvent;
-    public event EventHandler<CursorGotoEventArgs> CursorGotoEvent;
-    public event EventHandler<HighlightSetEventArgs> HighlightSetEvent;
-    public event EventHandler<PutEventArgs> PutEvent;
-    public event EventHandler<SetScrollRegionEventArgs> SetScrollRegionEvent;
-    public event EventHandler<ScrollEventArgs> ScrollEvent;
-    public event EventHandler<DefaultColorsSetEventArgs> DefaultColorsSetEvent;
-    public event EventHandler<HlAttrDefineEventArgs> HlAttrDefineEvent;
-    public event EventHandler<HlGroupSetEventArgs> HlGroupSetEvent;
-    public event EventHandler<GridResizeEventArgs> GridResizeEvent;
-    public event EventHandler<GridClearEventArgs> GridClearEvent;
-    public event EventHandler<GridCursorGotoEventArgs> GridCursorGotoEvent;
-    public event EventHandler<GridLineEventArgs> GridLineEvent;
-    public event EventHandler<GridScrollEventArgs> GridScrollEvent;
-    public event EventHandler<GridDestroyEventArgs> GridDestroyEvent;
-    public event EventHandler<WinPosEventArgs> WinPosEvent;
-    public event EventHandler<WinFloatPosEventArgs> WinFloatPosEvent;
-    public event EventHandler<WinExternalPosEventArgs> WinExternalPosEvent;
-    public event EventHandler<WinHideEventArgs> WinHideEvent;
-    public event EventHandler<WinCloseEventArgs> WinCloseEvent;
-    public event EventHandler<MsgSetPosEventArgs> MsgSetPosEvent;
-    public event EventHandler<WinViewportEventArgs> WinViewportEvent;
-    public event EventHandler<PopupmenuShowEventArgs> PopupmenuShowEvent;
-    public event EventHandler PopupmenuHideEvent;
-    public event EventHandler<PopupmenuSelectEventArgs> PopupmenuSelectEvent;
-    public event EventHandler<TablineUpdateEventArgs> TablineUpdateEvent;
-    public event EventHandler<CmdlineShowEventArgs> CmdlineShowEvent;
-    public event EventHandler<CmdlinePosEventArgs> CmdlinePosEvent;
-    public event EventHandler<CmdlineSpecialCharEventArgs> CmdlineSpecialCharEvent;
-    public event EventHandler<CmdlineHideEventArgs> CmdlineHideEvent;
-    public event EventHandler<CmdlineBlockShowEventArgs> CmdlineBlockShowEvent;
-    public event EventHandler<CmdlineBlockAppendEventArgs> CmdlineBlockAppendEvent;
-    public event EventHandler CmdlineBlockHideEvent;
-    public event EventHandler<WildmenuShowEventArgs> WildmenuShowEvent;
-    public event EventHandler<WildmenuSelectEventArgs> WildmenuSelectEvent;
-    public event EventHandler WildmenuHideEvent;
-    public event EventHandler<MsgShowEventArgs> MsgShowEvent;
-    public event EventHandler MsgClearEvent;
-    public event EventHandler<MsgShowcmdEventArgs> MsgShowcmdEvent;
-    public event EventHandler<MsgShowmodeEventArgs> MsgShowmodeEvent;
-    public event EventHandler<MsgRulerEventArgs> MsgRulerEvent;
-    public event EventHandler<MsgHistoryShowEventArgs> MsgHistoryShowEvent;
-
-    /// <summary>
-    /// <para>
-    /// Deprecated
-    /// </para>
-    /// </summary>
-    public Task<string> CommandOutput(string @command) =>
-      SendAndReceive<string>(new NvimRequest
-      {
-        Method = "nvim_command_output",
-        Arguments = GetRequestArguments(
-          @command)
-      });
-
-    /// <summary>
-    /// <para>
-    /// DeprecatedUse nvim_exec_lua() instead. 
-    /// </para>
-    /// </summary>
-    public Task<object> ExecuteLua(string @code, object[] @args) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_execute_lua",
-        Arguments = GetRequestArguments(
-          @code, @args)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Activates UI events on the channel.
-    /// </para>
-    /// </summary>
-    /// <param name="width">
-    /// <para>
-    /// Requested screen columns 
-    /// </para>
-    /// </param>
-    /// <param name="height">
-    /// <para>
-    /// Requested screen rows 
-    /// </para>
-    /// </param>
-    /// <param name="options">
-    /// <para>
-    /// |ui-option| map 
-    /// </para>
-    /// </param>
-    /// <remarks>
-    /// If multiple UI clients are attached, the global screen dimensions degrade to the smallest client. E.g. if client A requests 80x40 but client B requests 200x100, the global screen has size 80x40.
-    /// </remarks>
-    public Task UiAttach(long @width, long @height, IDictionary @options) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_ui_attach",
-        Arguments = GetRequestArguments(
-          @width, @height, @options)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Deactivates UI events on the channel.
-    /// </para>
-    /// </summary>
-    public Task UiDetach() =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_ui_detach",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    public Task UiTryResize(long @width, long @height) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_ui_try_resize",
-        Arguments = GetRequestArguments(
-          @width, @height)
-      });
-
-    public Task UiSetOption(string @name, object @value) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_ui_set_option",
-        Arguments = GetRequestArguments(
-          @name, @value)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Tell Nvim to resize a grid. Triggers a grid_resize event with the requested grid size or the maximum size if it exceeds size limits.
-    /// </para>
-    /// </summary>
-    /// <param name="grid">
-    /// <para>
-    /// The handle of the grid to be changed. 
-    /// </para>
-    /// </param>
-    /// <param name="width">
-    /// <para>
-    /// The new requested width. 
-    /// </para>
-    /// </param>
-    /// <param name="height">
-    /// <para>
-    /// The new requested height. 
-    /// </para>
-    /// </param>
-    public Task UiTryResizeGrid(long @grid, long @width, long @height) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_ui_try_resize_grid",
-        Arguments = GetRequestArguments(
-          @grid, @width, @height)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Tells Nvim the number of elements displaying in the popumenu, to decide &lt;PageUp&gt; and &lt;PageDown&gt; movement.
-    /// </para>
-    /// </summary>
-    /// <param name="height">
-    /// <para>
-    /// Popupmenu height, must be greater than zero. 
-    /// </para>
-    /// </param>
-    public Task UiPumSetHeight(long @height) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_ui_pum_set_height",
-        Arguments = GetRequestArguments(
-          @height)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Tells Nvim the geometry of the popumenu, to align floating windows with an external popup menu.
-    /// </para>
-    /// </summary>
-    /// <param name="width">
-    /// <para>
-    /// Popupmenu width. 
-    /// </para>
-    /// </param>
-    /// <param name="height">
-    /// <para>
-    /// Popupmenu height. 
-    /// </para>
-    /// </param>
-    /// <param name="row">
-    /// <para>
-    /// Popupmenu row. 
-    /// </para>
-    /// </param>
-    /// <param name="col">
-    /// <para>
-    /// Popupmenu height. 
-    /// </para>
-    /// </param>
-    public Task UiPumSetBounds(double @width, double @height, double @row, double @col) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_ui_pum_set_bounds",
-        Arguments = GetRequestArguments(
-          @width, @height, @row, @col)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Executes Vimscript (multiline block of Ex-commands), like anonymous |:source|.
-    /// </para>
-    /// </summary>
-    /// <param name="src">
-    /// <para>
-    /// Vimscript code 
-    /// </para>
-    /// </param>
-    /// <param name="output">
-    /// <para>
-    /// Capture and return all (non-error, non-shell |:!|) output 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Output (non-error, non-shell |:!|) if 
-    /// </para>
-    /// </returns>
-    public Task<string> Exec(string @src, bool @output) =>
-      SendAndReceive<string>(new NvimRequest
-      {
-        Method = "nvim_exec",
-        Arguments = GetRequestArguments(
-          @src, @output)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Executes an ex-command.
-    /// </para>
-    /// </summary>
-    /// <param name="command">
-    /// <para>
-    /// Ex-command string 
-    /// </para>
-    /// </param>
-    public Task Command(string @command) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_command",
-        Arguments = GetRequestArguments(
-          @command)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a highlight definition by name.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Highlight group name 
-    /// </para>
-    /// </param>
-    /// <param name="rgb">
-    /// <para>
-    /// Export RGB colors 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Highlight definition map 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetHlByName(string @name, bool @rgb) =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_hl_by_name",
-        Arguments = GetRequestArguments(
-          @name, @rgb)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a highlight definition by id. |hlID()|
-    /// </para>
-    /// </summary>
-    /// <param name="hlId">
-    /// <para>
-    /// Highlight id as returned by |hlID()| 
-    /// </para>
-    /// </param>
-    /// <param name="rgb">
-    /// <para>
-    /// Export RGB colors 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Highlight definition map 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetHlById(long @hlId, bool @rgb) =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_hl_by_id",
-        Arguments = GetRequestArguments(
-          @hlId, @rgb)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a highlight group by name
-    /// </para>
-    /// </summary>
-    public Task<long> GetHlIdByName(string @name) =>
-      SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_get_hl_id_by_name",
-        Arguments = GetRequestArguments(
-          @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Set a highlight group.
-    /// </para>
-    /// </summary>
-    /// <param name="nsId">
-    /// <para>
-    /// number of namespace for this highlight 
-    /// </para>
-    /// </param>
-    /// <param name="name">
-    /// <para>
-    /// highlight group name, like ErrorMsg 
-    /// </para>
-    /// </param>
-    /// <param name="val">
-    /// <para>
-    /// highlight definition map, like |nvim_get_hl_by_name|. in addition the following keys are also recognized: 
-    /// </para>
-    /// </param>
-    public Task SetHl(long @nsId, string @name, IDictionary @val) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_hl",
-        Arguments = GetRequestArguments(
-          @nsId, @name, @val)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sends input-keys to Nvim, subject to various quirks controlled by 
-    /// </para>
-    /// </summary>
-    /// <param name="keys">
-    /// <para>
-    /// to be typed 
-    /// </para>
-    /// </param>
-    /// <param name="mode">
-    /// <para>
-    /// behavior flags, see |feedkeys()| 
-    /// </para>
-    /// </param>
-    /// <param name="escapeCsi">
-    /// <para>
-    /// If true, escape K_SPECIAL/CSI bytes in 
-    /// </para>
-    /// </param>
-    public Task Feedkeys(string @keys, string @mode, bool @escapeCsi) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_feedkeys",
-        Arguments = GetRequestArguments(
-          @keys, @mode, @escapeCsi)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Queues raw user-input. Unlike |nvim_feedkeys()|, this uses a low-level input buffer and the call is non-blocking (input is processed asynchronously by the eventloop).
-    /// </para>
-    /// </summary>
-    /// <param name="keys">
-    /// <para>
-    /// to be typed 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Number of bytes actually written (can be fewer than requested if the buffer becomes full). 
-    /// </para>
-    /// </returns>
-    /// <remarks>
-    /// |keycodes| like &lt;CR&gt; are translated, so &quot;&lt;&quot; is special. To input a literal &quot;&lt;&quot;, send &lt;LT&gt;.
-    /// </remarks>
-    public Task<long> Input(string @keys) =>
-      SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_input",
-        Arguments = GetRequestArguments(
-          @keys)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Send mouse event from GUI.
-    /// </para>
-    /// </summary>
-    /// <param name="button">
-    /// <para>
-    /// Mouse button: one of &quot;left&quot;, &quot;right&quot;, &quot;middle&quot;, &quot;wheel&quot;. 
-    /// </para>
-    /// </param>
-    /// <param name="action">
-    /// <para>
-    /// For ordinary buttons, one of &quot;press&quot;, &quot;drag&quot;, &quot;release&quot;. For the wheel, one of &quot;up&quot;, &quot;down&quot;, &quot;left&quot;, &quot;right&quot;. 
-    /// </para>
-    /// </param>
-    /// <param name="modifier">
-    /// <para>
-    /// String of modifiers each represented by a single char. The same specifiers are used as for a key press, except that the &quot;-&quot; separator is optional, so &quot;C-A-&quot;, &quot;c-a&quot; and &quot;CA&quot; can all be used to specify Ctrl+Alt+click. 
-    /// </para>
-    /// </param>
-    /// <param name="grid">
-    /// <para>
-    /// Grid number if the client uses |ui-multigrid|, else 0. 
-    /// </para>
-    /// </param>
-    /// <param name="row">
-    /// <para>
-    /// Mouse row-position (zero-based, like redraw events) 
-    /// </para>
-    /// </param>
-    /// <param name="col">
-    /// <para>
-    /// Mouse column-position (zero-based, like redraw events) 
-    /// </para>
-    /// </param>
-    /// <remarks>
-    /// Currently this doesn&apos;t support &quot;scripting&quot; multiple mouse events by calling it multiple times in a loop: the intermediate mouse positions will be ignored. It should be used to implement real-time mouse input in a GUI. The deprecated pseudokey form (&quot;&lt;LeftMouse&gt;&lt;col,row&gt;&quot;) of |nvim_input()| has the same limitation.
-    /// </remarks>
-    public Task InputMouse(string @button, string @action, string @modifier, long @grid, long @row, long @col) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_input_mouse",
-        Arguments = GetRequestArguments(
-          @button, @action, @modifier, @grid, @row, @col)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Replaces terminal codes and |keycodes| (&lt;CR&gt;, &lt;Esc&gt;, ...) in a string with the internal representation.
-    /// </para>
-    /// </summary>
-    /// <param name="str">
-    /// <para>
-    /// String to be converted. 
-    /// </para>
-    /// </param>
-    /// <param name="fromPart">
-    /// <para>
-    /// Legacy Vim parameter. Usually true. 
-    /// </para>
-    /// </param>
-    /// <param name="doLt">
-    /// <para>
-    /// Also translate &lt;lt&gt;. Ignored if 
-    /// </para>
-    /// </param>
-    /// <param name="special">
-    /// <para>
-    /// Replace |keycodes|, e.g. &lt;CR&gt; becomes a &quot;\n&quot; char. 
-    /// </para>
-    /// </param>
-    public Task<string> ReplaceTermcodes(string @str, bool @fromPart, bool @doLt, bool @special) =>
-      SendAndReceive<string>(new NvimRequest
-      {
-        Method = "nvim_replace_termcodes",
-        Arguments = GetRequestArguments(
-          @str, @fromPart, @doLt, @special)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Evaluates a VimL |expression|. Dictionaries and Lists are recursively expanded.
-    /// </para>
-    /// </summary>
-    /// <param name="expr">
-    /// <para>
-    /// VimL expression string 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Evaluation result or expanded object 
-    /// </para>
-    /// </returns>
-    public Task<object> Eval(string @expr) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_eval",
-        Arguments = GetRequestArguments(
-          @expr)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Execute Lua code. Parameters (if any) are available as 
-    /// </para>
-    /// </summary>
-    /// <param name="code">
-    /// <para>
-    /// Lua code to execute 
-    /// </para>
-    /// </param>
-    /// <param name="args">
-    /// <para>
-    /// Arguments to the code 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Return value of Lua code if present or NIL. 
-    /// </para>
-    /// </returns>
-    public Task<object> ExecLua(string @code, object[] @args) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_exec_lua",
-        Arguments = GetRequestArguments(
-          @code, @args)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Notify the user with a message
-    /// </para>
-    /// </summary>
-    /// <param name="msg">
-    /// <para>
-    /// Message to display to the user 
-    /// </para>
-    /// </param>
-    /// <param name="logLevel">
-    /// <para>
-    /// The log level 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Reserved for future use. 
-    /// </para>
-    /// </param>
-    public Task<object> Notify(string @msg, long @logLevel, IDictionary @opts) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_notify",
-        Arguments = GetRequestArguments(
-          @msg, @logLevel, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Calls a VimL function with the given arguments.
-    /// </para>
-    /// </summary>
-    /// <param name="fn">
-    /// <para>
-    /// Function to call 
-    /// </para>
-    /// </param>
-    /// <param name="args">
-    /// <para>
-    /// Function arguments packed in an Array 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Result of the function call 
-    /// </para>
-    /// </returns>
-    public Task<object> CallFunction(string @fn, object[] @args) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_call_function",
-        Arguments = GetRequestArguments(
-          @fn, @args)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Calls a VimL |Dictionary-function| with the given arguments.
-    /// </para>
-    /// </summary>
-    /// <param name="dict">
-    /// <para>
-    /// Dictionary, or String evaluating to a VimL |self| dict 
-    /// </para>
-    /// </param>
-    /// <param name="fn">
-    /// <para>
-    /// Name of the function defined on the VimL dict 
-    /// </para>
-    /// </param>
-    /// <param name="args">
-    /// <para>
-    /// Function arguments packed in an Array 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Result of the function call 
-    /// </para>
-    /// </returns>
-    public Task<object> CallDictFunction(object @dict, string @fn, object[] @args) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_call_dict_function",
-        Arguments = GetRequestArguments(
-          @dict, @fn, @args)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Calculates the number of display cells occupied by 
-    /// </para>
-    /// </summary>
-    /// <param name="text">
-    /// <para>
-    /// Some text 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Number of cells 
-    /// </para>
-    /// </returns>
-    public Task<long> Strwidth(string @text) =>
-      SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_strwidth",
-        Arguments = GetRequestArguments(
-          @text)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the paths contained in &apos;runtimepath&apos;.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// List of paths 
-    /// </para>
-    /// </returns>
-    public Task<string[]> ListRuntimePaths() =>
-      SendAndReceive<string[]>(new NvimRequest
-      {
-        Method = "nvim_list_runtime_paths",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Find files in runtime directories
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// pattern of files to search for 
-    /// </para>
-    /// </param>
-    /// <param name="all">
-    /// <para>
-    /// whether to return all matches or only the first 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// list of absolute paths to the found files 
-    /// </para>
-    /// </returns>
-    public Task<string[]> GetRuntimeFile(string @name, bool @all) =>
-      SendAndReceive<string[]>(new NvimRequest
-      {
-        Method = "nvim_get_runtime_file",
-        Arguments = GetRequestArguments(
-          @name, @all)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Changes the global working directory.
-    /// </para>
-    /// </summary>
-    /// <param name="dir">
-    /// <para>
-    /// Directory path 
-    /// </para>
-    /// </param>
-    public Task SetCurrentDir(string @dir) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_current_dir",
-        Arguments = GetRequestArguments(
-          @dir)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the current line.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Current line string 
-    /// </para>
-    /// </returns>
-    public Task<string> GetCurrentLine() =>
-      SendAndReceive<string>(new NvimRequest
-      {
-        Method = "nvim_get_current_line",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the current line.
-    /// </para>
-    /// </summary>
-    /// <param name="line">
-    /// <para>
-    /// Line contents 
-    /// </para>
-    /// </param>
-    public Task SetCurrentLine(string @line) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_current_line",
-        Arguments = GetRequestArguments(
-          @line)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Deletes the current line.
-    /// </para>
-    /// </summary>
-    public Task DelCurrentLine() =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_del_current_line",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a global (g:) variable.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </returns>
-    public Task<object> GetVar(string @name) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_get_var",
-        Arguments = GetRequestArguments(
-          @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets a global (g:) variable.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <param name="value">
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </param>
-    public Task SetVar(string @name, object @value) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_var",
-        Arguments = GetRequestArguments(
-          @name, @value)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Removes a global (g:) variable.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    public Task DelVar(string @name) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_del_var",
-        Arguments = GetRequestArguments(
-          @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a v: variable.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </returns>
-    public Task<object> GetVvar(string @name) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_get_vvar",
-        Arguments = GetRequestArguments(
-          @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets a v: variable, if it is not readonly.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <param name="value">
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </param>
-    public Task SetVvar(string @name, object @value) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_vvar",
-        Arguments = GetRequestArguments(
-          @name, @value)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets an option value string.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Option name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Option value (global) 
-    /// </para>
-    /// </returns>
-    public Task<object> GetOption(string @name) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_get_option",
-        Arguments = GetRequestArguments(
-          @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the option information for all options.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// dictionary of all options 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetAllOptionsInfo() =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_all_options_info",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the option information for one option
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Option name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Option Information 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetOptionInfo(string @name) =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_option_info",
-        Arguments = GetRequestArguments(
-          @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets an option value.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Option name 
-    /// </para>
-    /// </param>
-    /// <param name="value">
-    /// <para>
-    /// New option value 
-    /// </para>
-    /// </param>
-    public Task SetOption(string @name, object @value) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_option",
-        Arguments = GetRequestArguments(
-          @name, @value)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Echo a message.
-    /// </para>
-    /// </summary>
-    /// <param name="chunks">
-    /// <para>
-    /// A list of [text, hl_group] arrays, each representing a text chunk with specified highlight. 
-    /// </para>
-    /// </param>
-    /// <param name="history">
-    /// <para>
-    /// if true, add to |message-history|. 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters. Reserved for future use. 
-    /// </para>
-    /// </param>
-    public Task Echo(object[] @chunks, bool @history, IDictionary @opts) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_echo",
-        Arguments = GetRequestArguments(
-          @chunks, @history, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Writes a message to the Vim output buffer. Does not append &quot;\n&quot;, the message is buffered (won&apos;t display) until a linefeed is written.
-    /// </para>
-    /// </summary>
-    /// <param name="str">
-    /// <para>
-    /// Message 
-    /// </para>
-    /// </param>
-    public Task OutWrite(string @str) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_out_write",
-        Arguments = GetRequestArguments(
-          @str)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Writes a message to the Vim error buffer. Does not append &quot;\n&quot;, the message is buffered (won&apos;t display) until a linefeed is written.
-    /// </para>
-    /// </summary>
-    /// <param name="str">
-    /// <para>
-    /// Message 
-    /// </para>
-    /// </param>
-    public Task ErrWrite(string @str) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_err_write",
-        Arguments = GetRequestArguments(
-          @str)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Writes a message to the Vim error buffer. Appends &quot;\n&quot;, so the buffer is flushed (and displayed).
-    /// </para>
-    /// </summary>
-    /// <param name="str">
-    /// <para>
-    /// Message 
-    /// </para>
-    /// </param>
-    public Task ErrWriteln(string @str) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_err_writeln",
-        Arguments = GetRequestArguments(
-          @str)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the current list of buffer handles
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// List of buffer handles 
-    /// </para>
-    /// </returns>
-    public Task<NvimBuffer[]> ListBufs() =>
-      SendAndReceive<NvimBuffer[]>(new NvimRequest
-      {
-        Method = "nvim_list_bufs",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the current buffer.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Buffer handle 
-    /// </para>
-    /// </returns>
-    public Task<NvimBuffer> GetCurrentBuf() =>
-      SendAndReceive<NvimBuffer>(new NvimRequest
-      {
-        Method = "nvim_get_current_buf",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the current buffer.
-    /// </para>
-    /// </summary>
-    /// <param name="buffer">
-    /// <para>
-    /// Buffer handle 
-    /// </para>
-    /// </param>
-    public Task SetCurrentBuf(NvimBuffer @buffer) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_current_buf",
-        Arguments = GetRequestArguments(
-          @buffer)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the current list of window handles.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// List of window handles 
-    /// </para>
-    /// </returns>
-    public Task<NvimWindow[]> ListWins() =>
-      SendAndReceive<NvimWindow[]>(new NvimRequest
-      {
-        Method = "nvim_list_wins",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the current window.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Window handle 
-    /// </para>
-    /// </returns>
-    public Task<NvimWindow> GetCurrentWin() =>
-      SendAndReceive<NvimWindow>(new NvimRequest
-      {
-        Method = "nvim_get_current_win",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the current window.
-    /// </para>
-    /// </summary>
-    /// <param name="window">
-    /// <para>
-    /// Window handle 
-    /// </para>
-    /// </param>
-    public Task SetCurrentWin(NvimWindow @window) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_current_win",
-        Arguments = GetRequestArguments(
-          @window)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Creates a new, empty, unnamed buffer.
-    /// </para>
-    /// </summary>
-    /// <param name="listed">
-    /// <para>
-    /// Sets &apos;buflisted&apos; 
-    /// </para>
-    /// </param>
-    /// <param name="scratch">
-    /// <para>
-    /// Creates a &quot;throwaway&quot; |scratch-buffer| for temporary work (always &apos;nomodified&apos;). Also sets &apos;nomodeline&apos; on the buffer. 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Buffer handle, or 0 on error
-    /// </para>
-    /// </returns>
-    public Task<NvimBuffer> CreateBuf(bool @listed, bool @scratch) =>
-      SendAndReceive<NvimBuffer>(new NvimRequest
-      {
-        Method = "nvim_create_buf",
-        Arguments = GetRequestArguments(
-          @listed, @scratch)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Open a terminal instance in a buffer
-    /// </para>
-    /// </summary>
-    /// <param name="buffer">
-    /// <para>
-    /// the buffer to use (expected to be empty) 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters. Reserved for future use. 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Channel id, or 0 on error 
-    /// </para>
-    /// </returns>
-    public Task<long> OpenTerm(NvimBuffer @buffer, IDictionary @opts) =>
-      SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_open_term",
-        Arguments = GetRequestArguments(
-          @buffer, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Send data to channel 
-    /// </para>
-    /// </summary>
-    /// <param name="chan">
-    /// <para>
-    /// id of the channel 
-    /// </para>
-    /// </param>
-    /// <param name="data">
-    /// <para>
-    /// data to write. 8-bit clean: can contain NUL bytes. 
-    /// </para>
-    /// </param>
-    public Task ChanSend(long @chan, string @data) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_chan_send",
-        Arguments = GetRequestArguments(
-          @chan, @data)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Open a new window.
-    /// </para>
-    /// </summary>
-    /// <param name="buffer">
-    /// <para>
-    /// Buffer to display, or 0 for current buffer 
-    /// </para>
-    /// </param>
-    /// <param name="enter">
-    /// <para>
-    /// Enter the window (make it the current window) 
-    /// </para>
-    /// </param>
-    /// <param name="config">
-    /// <para>
-    /// Map defining the window configuration. Keys:
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Window handle, or 0 on error 
-    /// </para>
-    /// </returns>
-    public Task<NvimWindow> OpenWin(NvimBuffer @buffer, bool @enter, IDictionary @config) =>
-      SendAndReceive<NvimWindow>(new NvimRequest
-      {
-        Method = "nvim_open_win",
-        Arguments = GetRequestArguments(
-          @buffer, @enter, @config)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the current list of tabpage handles.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// List of tabpage handles 
-    /// </para>
-    /// </returns>
-    public Task<NvimTabpage[]> ListTabpages() =>
-      SendAndReceive<NvimTabpage[]>(new NvimRequest
-      {
-        Method = "nvim_list_tabpages",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the current tabpage.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Tabpage handle 
-    /// </para>
-    /// </returns>
-    public Task<NvimTabpage> GetCurrentTabpage() =>
-      SendAndReceive<NvimTabpage>(new NvimRequest
-      {
-        Method = "nvim_get_current_tabpage",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the current tabpage.
-    /// </para>
-    /// </summary>
-    /// <param name="tabpage">
-    /// <para>
-    /// Tabpage handle 
-    /// </para>
-    /// </param>
-    public Task SetCurrentTabpage(NvimTabpage @tabpage) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_current_tabpage",
-        Arguments = GetRequestArguments(
-          @tabpage)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Creates a new namespace, or gets an existing one.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Namespace name or empty string 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Namespace id 
-    /// </para>
-    /// </returns>
-    public Task<long> CreateNamespace(string @name) =>
-      SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_create_namespace",
-        Arguments = GetRequestArguments(
-          @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets existing, non-anonymous namespaces.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// dict that maps from names to namespace ids. 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetNamespaces() =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_namespaces",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Pastes at cursor, in any mode.
-    /// </para>
-    /// </summary>
-    /// <param name="data">
-    /// <para>
-    /// Multiline input. May be binary (containing NUL bytes). 
-    /// </para>
-    /// </param>
-    /// <param name="crlf">
-    /// <para>
-    /// Also break lines at CR and CRLF. 
-    /// </para>
-    /// </param>
-    /// <param name="phase">
-    /// <para>
-    /// -1: paste in a single call (i.e. without streaming). To &quot;stream&quot; a paste, call 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// <list type="bullet">
-    /// <item><description>
-    /// true: Client may continue pasting.
-    /// </description></item>
-    /// </list>
-    /// </para>
-    /// </returns>
-    public Task<bool> Paste(string @data, bool @crlf, long @phase) =>
-      SendAndReceive<bool>(new NvimRequest
-      {
-        Method = "nvim_paste",
-        Arguments = GetRequestArguments(
-          @data, @crlf, @phase)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Puts text at cursor, in any mode.
-    /// </para>
-    /// </summary>
-    /// <param name="lines">
-    /// <para>
-    /// |readfile()|-style list of lines. |channel-lines| 
-    /// </para>
-    /// </param>
-    /// <param name="type">
-    /// <para>
-    /// Edit behavior: any |getregtype()| result, or:
-    /// </para>
-    /// </param>
-    /// <param name="after">
-    /// <para>
-    /// If true insert after cursor (like |p|), or before (like |P|). 
-    /// </para>
-    /// </param>
-    /// <param name="follow">
-    /// <para>
-    /// If true place cursor at end of inserted text. 
-    /// </para>
-    /// </param>
-    public Task Put(string[] @lines, string @type, bool @after, bool @follow) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_put",
-        Arguments = GetRequestArguments(
-          @lines, @type, @after, @follow)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Subscribes to event broadcasts.
-    /// </para>
-    /// </summary>
-    /// <param name="event">
-    /// <para>
-    /// Event type string 
-    /// </para>
-    /// </param>
-    public Task Subscribe(string @event) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_subscribe",
-        Arguments = GetRequestArguments(
-          @event)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Unsubscribes to event broadcasts.
-    /// </para>
-    /// </summary>
-    /// <param name="event">
-    /// <para>
-    /// Event type string 
-    /// </para>
-    /// </param>
-    public Task Unsubscribe(string @event) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_unsubscribe",
-        Arguments = GetRequestArguments(
-          @event)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Returns the 24-bit RGB value of a |nvim_get_color_map()| color name or &quot;#rrggbb&quot; hexadecimal string.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Color name or &quot;#rrggbb&quot; string 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// 24-bit RGB value, or -1 for invalid argument. 
-    /// </para>
-    /// </returns>
-    public Task<long> GetColorByName(string @name) =>
-      SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_get_color_by_name",
-        Arguments = GetRequestArguments(
-          @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Returns a map of color names and RGB values.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Map of color names and RGB values. 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetColorMap() =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_color_map",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a map of the current editor state.
-    /// </para>
-    /// </summary>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters.
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// map of global |context|. 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetContext(IDictionary @opts) =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_context",
-        Arguments = GetRequestArguments(
-          @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the current editor state from the given |context| map.
-    /// </para>
-    /// </summary>
-    /// <param name="dict">
-    /// <para>
-    /// |Context| map. 
-    /// </para>
-    /// </param>
-    public Task<object> LoadContext(IDictionary @dict) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_load_context",
-        Arguments = GetRequestArguments(
-          @dict)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the current mode. |mode()| &quot;blocking&quot; is true if Nvim is waiting for input.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Dictionary { &quot;mode&quot;: String, &quot;blocking&quot;: Boolean } 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetMode() =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_mode",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a list of global (non-buffer-local) |mapping| definitions.
-    /// </para>
-    /// </summary>
-    /// <param name="mode">
-    /// <para>
-    /// Mode short-name (&quot;n&quot;, &quot;i&quot;, &quot;v&quot;, ...) 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Array of maparg()-like dictionaries describing mappings. The &quot;buffer&quot; key is always zero. 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary[]> GetKeymap(string @mode) =>
-      SendAndReceive<IDictionary[]>(new NvimRequest
-      {
-        Method = "nvim_get_keymap",
-        Arguments = GetRequestArguments(
-          @mode)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets a global |mapping| for the given mode.
-    /// </para>
-    /// </summary>
-    /// <param name="mode">
-    /// <para>
-    /// Mode short-name (map command prefix: &quot;n&quot;, &quot;i&quot;, &quot;v&quot;, &quot;x&quot;, …) or &quot;!&quot; for |:map!|, or empty string for |:map|. 
-    /// </para>
-    /// </param>
-    /// <param name="lhs">
-    /// <para>
-    /// Left-hand-side |{lhs}| of the mapping. 
-    /// </para>
-    /// </param>
-    /// <param name="rhs">
-    /// <para>
-    /// Right-hand-side |{rhs}| of the mapping. 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters map. Accepts all |:map-arguments| as keys excluding |&lt;buffer&gt;| but including |noremap|. Values are Booleans. Unknown key is an error. 
-    /// </para>
-    /// </param>
-    public Task SetKeymap(string @mode, string @lhs, string @rhs, IDictionary @opts) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_keymap",
-        Arguments = GetRequestArguments(
-          @mode, @lhs, @rhs, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Unmaps a global |mapping| for the given mode.
-    /// </para>
-    /// </summary>
-    public Task DelKeymap(string @mode, string @lhs) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_del_keymap",
-        Arguments = GetRequestArguments(
-          @mode, @lhs)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a map of global (non-buffer-local) Ex commands.
-    /// </para>
-    /// </summary>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters. Currently only supports {&quot;builtin&quot;:false} 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Map of maps describing commands. 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetCommands(IDictionary @opts) =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_commands",
-        Arguments = GetRequestArguments(
-          @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Returns a 2-tuple (Array), where item 0 is the current channel id and item 1 is the |api-metadata| map (Dictionary).
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// 2-tuple [{channel-id}, {api-metadata}] 
-    /// </para>
-    /// </returns>
-    public Task<object[]> GetApiInfo() =>
-      SendAndReceive<object[]>(new NvimRequest
-      {
-        Method = "nvim_get_api_info",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Self-identifies the client.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Short name for the connected client 
-    /// </para>
-    /// </param>
-    /// <param name="version">
-    /// <para>
-    /// Dictionary describing the version, with these (optional) keys:
-    /// </para>
-    /// </param>
-    /// <param name="type">
-    /// <para>
-    /// Must be one of the following values. Client libraries should default to &quot;remote&quot; unless overridden by the user.
-    /// </para>
-    /// </param>
-    /// <param name="methods">
-    /// <para>
-    /// Builtin methods in the client. For a host, this does not include plugin methods which will be discovered later. The key should be the method name, the values are dicts with these (optional) keys (more keys may be added in future versions of Nvim, thus unknown keys are ignored. Clients must only use keys defined in this or later versions of Nvim):
-    /// </para>
-    /// </param>
-    /// <param name="attributes">
-    /// <para>
-    /// Arbitrary string:string map of informal client properties. Suggested keys:
-    /// </para>
-    /// </param>
-    /// <remarks>
-    /// &quot;Something is better than nothing&quot;. You don&apos;t need to include all the fields.
-    /// </remarks>
-    public Task SetClientInfo(string @name, IDictionary @version, string @type, IDictionary @methods, IDictionary @attributes) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_client_info",
-        Arguments = GetRequestArguments(
-          @name, @version, @type, @methods, @attributes)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Get information about a channel.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Dictionary describing a channel, with these keys:
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetChanInfo(long @chan) =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_get_chan_info",
-        Arguments = GetRequestArguments(
-          @chan)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Get information about all open channels.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Array of Dictionaries, each describing a channel with the format specified at |nvim_get_chan_info()|. 
-    /// </para>
-    /// </returns>
-    public Task<object[]> ListChans() =>
-      SendAndReceive<object[]>(new NvimRequest
-      {
-        Method = "nvim_list_chans",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Calls many API methods atomically.
-    /// </para>
-    /// </summary>
-    /// <param name="calls">
-    /// <para>
-    /// an array of calls, where each call is described by an array with two elements: the request name, and an array of arguments. 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Array of two elements. The first is an array of return values. The second is NIL if all calls succeeded. If a call resulted in an error, it is a three-element array with the zero-based index of the call which resulted in an error, the error type and the error message. If an error occurred, the values from all preceding calls will still be returned. 
-    /// </para>
-    /// </returns>
-    public Task<object[]> CallAtomic(object[] @calls) =>
-      SendAndReceive<object[]>(new NvimRequest
-      {
-        Method = "nvim_call_atomic",
-        Arguments = GetRequestArguments(
-          @calls)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Parse a VimL expression.
-    /// </para>
-    /// </summary>
-    /// <param name="expr">
-    /// <para>
-    /// Expression to parse. Always treated as a single line. 
-    /// </para>
-    /// </param>
-    /// <param name="flags">
-    /// <para>
-    /// Flags:
-    /// </para>
-    /// </param>
-    /// <param name="highlight">
-    /// <para>
-    /// If true, return value will also include &quot;highlight&quot; key containing array of 4-tuples (arrays) (Integer, Integer, Integer, String), where first three numbers define the highlighted region and represent line, starting column and ending column (latter exclusive: one should highlight region [start_col, end_col)).
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// <list type="bullet">
-    /// <item><description>
-    /// AST: top-level dictionary with these keys:&quot;error&quot;: Dictionary with error, present only if parser saw some error. Contains the following keys:&quot;message&quot;: String, error message in printf format, translated. Must contain exactly one &quot;%.*s&quot;.&quot;arg&quot;: String, error message argument.&quot;len&quot;: Amount of bytes successfully parsed. With flags equal to &quot;&quot; that should be equal to the length of expr string. (“Successfully parsed” here means “participated in AST creation”, not “till the first error”.)&quot;ast&quot;: AST, either nil or a dictionary with these keys:&quot;type&quot;: node type, one of the value names from ExprASTNodeType stringified without &quot;kExprNode&quot; prefix.&quot;start&quot;: a pair [line, column] describing where node is &quot;started&quot; where &quot;line&quot; is always 0 (will not be 0 if you will be using nvim_parse_viml() on e.g. &quot;:let&quot;, but that is not present yet). Both elements are Integers.&quot;len&quot;: “length” of the node. This and &quot;start&quot; are there for debugging purposes primary (debugging parser and providing debug information).&quot;children&quot;: a list of nodes described in top/&quot;ast&quot;. There always is zero, one or two children, key will not be present if node has no children. Maximum number of children may be found in node_maxchildren array.
-    /// </description></item>
-    /// </list>
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> ParseExpression(string @expr, string @flags, bool @highlight) =>
-      SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_parse_expression",
-        Arguments = GetRequestArguments(
-          @expr, @flags, @highlight)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a list of dictionaries representing attached UIs.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Array of UI dictionaries, each with these keys:
-    /// </para>
-    /// </returns>
-    public Task<object[]> ListUis() =>
-      SendAndReceive<object[]>(new NvimRequest
-      {
-        Method = "nvim_list_uis",
-        Arguments = GetRequestArguments(
-          )
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the immediate children of process 
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Array of child process ids, empty if process not found. 
-    /// </para>
-    /// </returns>
-    public Task<object[]> GetProcChildren(long @pid) =>
-      SendAndReceive<object[]>(new NvimRequest
-      {
-        Method = "nvim_get_proc_children",
-        Arguments = GetRequestArguments(
-          @pid)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets info describing process 
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Map of process properties, or NIL if process not found. 
-    /// </para>
-    /// </returns>
-    public Task<object> GetProc(long @pid) =>
-      SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_get_proc",
-        Arguments = GetRequestArguments(
-          @pid)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Selects an item in the completion popupmenu.
-    /// </para>
-    /// </summary>
-    /// <param name="item">
-    /// <para>
-    /// Index (zero-based) of the item to select. Value of -1 selects nothing and restores the original text. 
-    /// </para>
-    /// </param>
-    /// <param name="insert">
-    /// <para>
-    /// Whether the selection should be inserted in the buffer. 
-    /// </para>
-    /// </param>
-    /// <param name="finish">
-    /// <para>
-    /// Finish the completion and dismiss the popupmenu. Implies 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters. Reserved for future use. 
-    /// </para>
-    /// </param>
-    public Task SelectPopupmenuItem(long @item, bool @insert, bool @finish, IDictionary @opts) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_select_popupmenu_item",
-        Arguments = GetRequestArguments(
-          @item, @insert, @finish, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Set or change decoration provider for a namespace
-    /// </para>
-    /// </summary>
-    /// <param name="nsId">
-    /// <para>
-    /// Namespace id from |nvim_create_namespace()| 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Callbacks invoked during redraw:
-    /// </para>
-    /// </param>
-    public Task SetDecorationProvider(long @nsId, IDictionary @opts) =>
-      SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_set_decoration_provider",
-        Arguments = GetRequestArguments(
-          @nsId, @opts)
-      });
-
-
-  public class NvimBuffer
-  {
-    private readonly NvimAPI _api;
-    private readonly MessagePackExtendedTypeObject _msgPackExtObj;
-    internal NvimBuffer(NvimAPI api, MessagePackExtendedTypeObject msgPackExtObj)
+    public partial class NvimAPI
     {
-      _api = api;
-      _msgPackExtObj = msgPackExtObj;
+        public event EventHandler<ModeInfoSetEventArgs> ModeInfoSetEvent;
+        public event EventHandler UpdateMenuEvent;
+        public event EventHandler BusyStartEvent;
+        public event EventHandler BusyStopEvent;
+        public event EventHandler MouseOnEvent;
+        public event EventHandler MouseOffEvent;
+        public event EventHandler<ModeChangeEventArgs> ModeChangeEvent;
+        public event EventHandler BellEvent;
+        public event EventHandler VisualBellEvent;
+        public event EventHandler FlushEvent;
+        public event EventHandler<ConnectEventArgs> ConnectEvent;
+        public event EventHandler<RestartEventArgs> RestartEvent;
+        public event EventHandler SuspendEvent;
+        public event EventHandler<SetTitleEventArgs> SetTitleEvent;
+        public event EventHandler<SetIconEventArgs> SetIconEvent;
+        public event EventHandler<ScreenshotEventArgs> ScreenshotEvent;
+        public event EventHandler<OptionSetEventArgs> OptionSetEvent;
+        public event EventHandler<ChdirEventArgs> ChdirEvent;
+        public event EventHandler<UiSendEventArgs> UiSendEvent;
+        public event EventHandler<UpdateFgEventArgs> UpdateFgEvent;
+        public event EventHandler<UpdateBgEventArgs> UpdateBgEvent;
+        public event EventHandler<UpdateSpEventArgs> UpdateSpEvent;
+        public event EventHandler<ResizeEventArgs> ResizeEvent;
+        public event EventHandler ClearEvent;
+        public event EventHandler EolClearEvent;
+        public event EventHandler<CursorGotoEventArgs> CursorGotoEvent;
+        public event EventHandler<HighlightSetEventArgs> HighlightSetEvent;
+        public event EventHandler<PutEventArgs> PutEvent;
+        public event EventHandler<SetScrollRegionEventArgs> SetScrollRegionEvent;
+        public event EventHandler<ScrollEventArgs> ScrollEvent;
+        public event EventHandler<DefaultColorsSetEventArgs> DefaultColorsSetEvent;
+        public event EventHandler<HlAttrDefineEventArgs> HlAttrDefineEvent;
+        public event EventHandler<HlGroupSetEventArgs> HlGroupSetEvent;
+        public event EventHandler<GridResizeEventArgs> GridResizeEvent;
+        public event EventHandler<GridClearEventArgs> GridClearEvent;
+        public event EventHandler<GridCursorGotoEventArgs> GridCursorGotoEvent;
+        public event EventHandler<GridLineEventArgs> GridLineEvent;
+        public event EventHandler<GridScrollEventArgs> GridScrollEvent;
+        public event EventHandler<GridDestroyEventArgs> GridDestroyEvent;
+        public event EventHandler<WinPosEventArgs> WinPosEvent;
+        public event EventHandler<WinFloatPosEventArgs> WinFloatPosEvent;
+        public event EventHandler<WinExternalPosEventArgs> WinExternalPosEvent;
+        public event EventHandler<WinHideEventArgs> WinHideEvent;
+        public event EventHandler<WinCloseEventArgs> WinCloseEvent;
+        public event EventHandler<MsgSetPosEventArgs> MsgSetPosEvent;
+        public event EventHandler<WinViewportEventArgs> WinViewportEvent;
+        public event EventHandler<WinViewportMarginsEventArgs> WinViewportMarginsEvent;
+        public event EventHandler<WinExtmarkEventArgs> WinExtmarkEvent;
+        public event EventHandler<PopupmenuShowEventArgs> PopupmenuShowEvent;
+        public event EventHandler PopupmenuHideEvent;
+        public event EventHandler<PopupmenuSelectEventArgs> PopupmenuSelectEvent;
+        public event EventHandler<TablineUpdateEventArgs> TablineUpdateEvent;
+        public event EventHandler<CmdlineShowEventArgs> CmdlineShowEvent;
+        public event EventHandler<CmdlinePosEventArgs> CmdlinePosEvent;
+        public event EventHandler<CmdlineSpecialCharEventArgs> CmdlineSpecialCharEvent;
+        public event EventHandler<CmdlineHideEventArgs> CmdlineHideEvent;
+        public event EventHandler<CmdlineBlockShowEventArgs> CmdlineBlockShowEvent;
+        public event EventHandler<CmdlineBlockAppendEventArgs> CmdlineBlockAppendEvent;
+        public event EventHandler CmdlineBlockHideEvent;
+        public event EventHandler<WildmenuShowEventArgs> WildmenuShowEvent;
+        public event EventHandler<WildmenuSelectEventArgs> WildmenuSelectEvent;
+        public event EventHandler WildmenuHideEvent;
+        public event EventHandler<MsgShowEventArgs> MsgShowEvent;
+        public event EventHandler MsgClearEvent;
+        public event EventHandler<MsgShowcmdEventArgs> MsgShowcmdEvent;
+        public event EventHandler<MsgShowmodeEventArgs> MsgShowmodeEvent;
+        public event EventHandler<MsgRulerEventArgs> MsgRulerEvent;
+        public event EventHandler<MsgHistoryShowEventArgs> MsgHistoryShowEvent;
+        public event EventHandler<ErrorExitEventArgs> ErrorExitEvent;
+
+        /// <summary>
+        /// <para>
+        /// Gets all autocommands matching ALL criteria in the {opts} query.
+        /// </para>
+        /// </summary>
+        /// <param name="opts">
+        /// <para>
+        /// Dict
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Array of matching autocommands, where each item has:
+        /// </para>
+        /// </returns>
+        public Task<object[]> GetAutocmds(IDictionary @opts) =>
+            SendAndReceive<object[]>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_autocmds",
+                    Arguments = GetRequestArguments(@opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Creates an |autocommand| event handler, defined by
+        /// </para>
+        /// </summary>
+        /// <param name="event">
+        /// <para>
+        /// Event(s) that will trigger the handler (
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Options dict:
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Autocommand id (number)
+        /// </para>
+        /// </returns>
+        public Task<long> CreateAutocmd(object @event, IDictionary @opts) =>
+            SendAndReceive<long>(
+                new NvimRequest
+                {
+                    Method = "nvim_create_autocmd",
+                    Arguments = GetRequestArguments(@event, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deletes an autocommand by id.
+        /// </para>
+        /// </summary>
+        /// <param name="id">
+        /// <para>
+        /// Autocommand id returned by |nvim_create_autocmd()|
+        /// </para>
+        /// </param>
+        public Task DelAutocmd(long @id) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_del_autocmd",
+                    Arguments = GetRequestArguments(@id),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Clears all autocommands matching the {opts} query. To delete autocmds see |nvim_del_autocmd()|.
+        /// </para>
+        /// </summary>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters:
+        /// </para>
+        /// </param>
+        public Task ClearAutocmds(IDictionary @opts) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_clear_autocmds",
+                    Arguments = GetRequestArguments(@opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Create or get an autocommand group |autocmd-groups|.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Group name
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters:
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Group id.
+        /// </para>
+        /// </returns>
+        public Task<long> CreateAugroup(string @name, IDictionary @opts) =>
+            SendAndReceive<long>(
+                new NvimRequest
+                {
+                    Method = "nvim_create_augroup",
+                    Arguments = GetRequestArguments(@name, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Delete an autocommand group by id.
+        /// </para>
+        /// </summary>
+        /// <param name="id">
+        /// <para>
+        /// Group id.
+        /// </para>
+        /// </param>
+        public Task DelAugroupById(long @id) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_del_augroup_by_id",
+                    Arguments = GetRequestArguments(@id),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Delete an autocommand group by name.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Group name.
+        /// </para>
+        /// </param>
+        public Task DelAugroupByName(string @name) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_del_augroup_by_name",
+                    Arguments = GetRequestArguments(@name),
+                }
+            );
+
+        /// <param name="event">
+        /// <para>
+        /// Event(s) to execute.
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional filters:
+        /// </para>
+        /// </param>
+        public Task ExecAutocmds(object @event, IDictionary @opts) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_exec_autocmds",
+                    Arguments = GetRequestArguments(@event, @opts),
+                }
+            );
+
+        public Task<IDictionary> ParseCmd(string @str, IDictionary @opts) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_parse_cmd",
+                    Arguments = GetRequestArguments(@str, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Executes an Ex command
+        /// </para>
+        /// </summary>
+        /// <param name="cmd">
+        /// <para>
+        /// Command to execute, a
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters.
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Command output (non-error, non-shell |:!|) if
+        /// </para>
+        /// </returns>
+        public Task<string> Cmd(IDictionary @cmd, IDictionary @opts) =>
+            SendAndReceive<string>(
+                new NvimRequest
+                {
+                    Method = "nvim_cmd",
+                    Arguments = GetRequestArguments(@cmd, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Creates a global |user-commands| command.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Name of the new user command. Must begin with an uppercase letter.
+        /// </para>
+        /// </param>
+        /// <param name="cmd">
+        /// <para>
+        /// Replacement command to execute when this user command is executed. When called from Lua, the command can also be a Lua function. The function is called with a single table argument that contains the following keys:
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional flags
+        /// </para>
+        /// </param>
+        public Task CreateUserCommand(string @name, object @cmd, IDictionary @opts) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_create_user_command",
+                    Arguments = GetRequestArguments(@name, @cmd, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Delete a user-defined command.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Name of the command to delete.
+        /// </para>
+        /// </param>
+        public Task DelUserCommand(string @name) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_del_user_command",
+                    Arguments = GetRequestArguments(@name),
+                }
+            );
+
+        public Task<IDictionary> GetCommands(IDictionary @opts) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_commands",
+                    Arguments = GetRequestArguments(@opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// DeprecatedUse nvim_exec2() instead.
+        /// </para>
+        /// </summary>
+        public Task<string> Exec(string @src, bool @output) =>
+            SendAndReceive<string>(
+                new NvimRequest
+                {
+                    Method = "nvim_exec",
+                    Arguments = GetRequestArguments(@src, @output),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deprecated
+        /// </para>
+        /// </summary>
+        public Task<string> CommandOutput(string @command) =>
+            SendAndReceive<string>(
+                new NvimRequest
+                {
+                    Method = "nvim_command_output",
+                    Arguments = GetRequestArguments(@command),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// DeprecatedUse nvim_exec_lua() instead.
+        /// </para>
+        /// </summary>
+        public Task<object> ExecuteLua(string @code, object[] @args) =>
+            SendAndReceive<object>(
+                new NvimRequest
+                {
+                    Method = "nvim_execute_lua",
+                    Arguments = GetRequestArguments(@code, @args),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets a highlight definition by id. |hlID()|
+        /// </para>
+        /// </summary>
+        /// <param name="hlId">
+        /// <para>
+        /// Highlight id as returned by |hlID()|
+        /// </para>
+        /// </param>
+        /// <param name="rgb">
+        /// <para>
+        /// Export RGB colors
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Highlight definition map
+        /// </para>
+        /// </returns>
+        public Task<IDictionary> GetHlById(long @hlId, bool @rgb) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_hl_by_id",
+                    Arguments = GetRequestArguments(@hlId, @rgb),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets a highlight definition by name.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Highlight group name
+        /// </para>
+        /// </param>
+        /// <param name="rgb">
+        /// <para>
+        /// Export RGB colors
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Highlight definition map
+        /// </para>
+        /// </returns>
+        public Task<IDictionary> GetHlByName(string @name, bool @rgb) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_hl_by_name",
+                    Arguments = GetRequestArguments(@name, @rgb),
+                }
+            );
+
+        public Task<IDictionary> GetOptionInfo(string @name) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_option_info",
+                    Arguments = GetRequestArguments(@name),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets the global value of an option.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Option name
+        /// </para>
+        /// </param>
+        /// <param name="value">
+        /// <para>
+        /// New option value
+        /// </para>
+        /// </param>
+        public Task SetOption(string @name, object @value) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_option",
+                    Arguments = GetRequestArguments(@name, @value),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the global value of an option.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Option name
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Option value (global)
+        /// </para>
+        /// </returns>
+        public Task<object> GetOption(string @name) =>
+            SendAndReceive<object>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_option",
+                    Arguments = GetRequestArguments(@name),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// DeprecatedUse nvim_exec_lua() instead.
+        /// </para>
+        /// </summary>
+        /// <param name="calls">
+        /// <para>
+        /// an array of calls, where each call is described by an array with two elements: the request name, and an array of arguments.
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Array of two elements. The first is an array of return values. The second is NIL if all calls succeeded. If a call resulted in an error, it is a three-element array with the zero-based index of the call which resulted in an error, the error type and the error message. If an error occurred, the values from all preceding calls will still be returned.
+        /// </para>
+        /// </returns>
+        public Task<object[]> CallAtomic(object[] @calls) =>
+            SendAndReceive<object[]>(
+                new NvimRequest
+                {
+                    Method = "nvim_call_atomic",
+                    Arguments = GetRequestArguments(@calls),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deprecated
+        /// </para>
+        /// </summary>
+        /// <param name="event">
+        /// <para>
+        /// Event type string
+        /// </para>
+        /// </param>
+        public Task Subscribe(string @event) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_subscribe",
+                    Arguments = GetRequestArguments(@event),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deprecated
+        /// </para>
+        /// </summary>
+        /// <param name="event">
+        /// <para>
+        /// Event type string
+        /// </para>
+        /// </param>
+        public Task Unsubscribe(string @event) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_unsubscribe",
+                    Arguments = GetRequestArguments(@event),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deprecated
+        /// </para>
+        /// </summary>
+        /// <param name="str">
+        /// <para>
+        /// Message
+        /// </para>
+        /// </param>
+        public Task OutWrite(string @str) =>
+            SendAndReceive(
+                new NvimRequest { Method = "nvim_out_write", Arguments = GetRequestArguments(@str) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deprecated
+        /// </para>
+        /// </summary>
+        /// <param name="str">
+        /// <para>
+        /// Message
+        /// </para>
+        /// </param>
+        public Task ErrWrite(string @str) =>
+            SendAndReceive(
+                new NvimRequest { Method = "nvim_err_write", Arguments = GetRequestArguments(@str) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deprecated
+        /// </para>
+        /// </summary>
+        /// <param name="str">
+        /// <para>
+        /// Message
+        /// </para>
+        /// </param>
+        public Task ErrWriteln(string @str) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_err_writeln",
+                    Arguments = GetRequestArguments(@str),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deprecated
+        /// </para>
+        /// </summary>
+        /// <param name="msg">
+        /// <para>
+        /// Message to display to the user
+        /// </para>
+        /// </param>
+        /// <param name="logLevel">
+        /// <para>
+        /// The log level
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Reserved for future use.
+        /// </para>
+        /// </param>
+        public Task<object> Notify(string @msg, long @logLevel, IDictionary @opts) =>
+            SendAndReceive<object>(
+                new NvimRequest
+                {
+                    Method = "nvim_notify",
+                    Arguments = GetRequestArguments(@msg, @logLevel, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Emitted by the TUI client to signal when a host-terminal event occurred.
+        /// </para>
+        /// </summary>
+        /// <param name="event">
+        /// <para>
+        /// Event name
+        /// </para>
+        /// </param>
+        /// <param name="value">
+        /// <para>
+        /// Event payload
+        /// </para>
+        /// </param>
+        public Task UiTermEvent(string @event, object @value) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_ui_term_event",
+                    Arguments = GetRequestArguments(@event, @value),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Creates a new namespace or gets an existing one. [namespace]()
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Namespace name or empty string
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Namespace id
+        /// </para>
+        /// </returns>
+        public Task<long> CreateNamespace(string @name) =>
+            SendAndReceive<long>(
+                new NvimRequest
+                {
+                    Method = "nvim_create_namespace",
+                    Arguments = GetRequestArguments(@name),
+                }
+            );
+
+        public Task<IDictionary> GetNamespaces() =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_namespaces",
+                    Arguments = GetRequestArguments(),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Set or change decoration provider for a |namespace|
+        /// </para>
+        /// </summary>
+        /// <param name="nsId">
+        /// <para>
+        /// Namespace id from |nvim_create_namespace()|
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Table of callbacks:
+        /// </para>
+        /// </param>
+        public Task SetDecorationProvider(long @nsId, IDictionary @opts) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_decoration_provider",
+                    Arguments = GetRequestArguments(@nsId, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the value of an option. The behavior of this function matches that of |:set|: the local value of an option is returned if it exists; otherwise, the global value is returned. Local values always correspond to the current buffer or window, unless &quot;buf&quot; or &quot;win&quot; is set in {opts}.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Option name
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Option value
+        /// </para>
+        /// </returns>
+        public Task<object> GetOptionValue(string @name, IDictionary @opts) =>
+            SendAndReceive<object>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_option_value",
+                    Arguments = GetRequestArguments(@name, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets the value of an option. The behavior of this function matches that of |:set|: for global-local options, both the global and local value are set unless otherwise specified with {scope}.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Option name
+        /// </para>
+        /// </param>
+        /// <param name="value">
+        /// <para>
+        /// New option value
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters
+        /// </para>
+        /// </param>
+        public Task SetOptionValue(string @name, object @value, IDictionary @opts) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_option_value",
+                    Arguments = GetRequestArguments(@name, @value, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the option information for all options.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// dict of all options
+        /// </para>
+        /// </returns>
+        public Task<IDictionary> GetAllOptionsInfo() =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_all_options_info",
+                    Arguments = GetRequestArguments(),
+                }
+            );
+
+        public Task<IDictionary> GetOptionInfo2(string @name, IDictionary @opts) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_option_info2",
+                    Arguments = GetRequestArguments(@name, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Opens a new tabpage.
+        /// </para>
+        /// </summary>
+        /// <param name="buf">
+        /// <para>
+        /// Buffer to open in the first window of the new tabpage. Use 0 for current buffer.
+        /// </para>
+        /// </param>
+        /// <param name="enter">
+        /// <para>
+        /// Enter the tabpage (make it the current tabpage).
+        /// </para>
+        /// </param>
+        /// <param name="config">
+        /// <para>
+        /// Configuration for the new tabpage. Keys:
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// |tab-ID| of the new tabpage
+        /// </para>
+        /// </returns>
+        public Task<NvimTabpage> OpenTabpage(NvimBuffer @buf, bool @enter, IDictionary @config) =>
+            SendAndReceive<NvimTabpage>(
+                new NvimRequest
+                {
+                    Method = "nvim_open_tabpage",
+                    Arguments = GetRequestArguments(@buf, @enter, @config),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Activates UI events on the channel.
+        /// </para>
+        /// </summary>
+        /// <param name="width">
+        /// <para>
+        /// Requested screen columns
+        /// </para>
+        /// </param>
+        /// <param name="height">
+        /// <para>
+        /// Requested screen rows
+        /// </para>
+        /// </param>
+        /// <param name="options">
+        /// <para>
+        /// |ui-option| map
+        /// </para>
+        /// </param>
+        /// <remarks>
+        /// If multiple UI clients are attached, the global screen dimensions degrade to the smallest client. E.g. if client A requests 80x40 but client B requests 200x100, the global screen has size 80x40.
+        /// </remarks>
+        public Task UiAttach(long @width, long @height, IDictionary @options) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_ui_attach",
+                    Arguments = GetRequestArguments(@width, @height, @options),
+                }
+            );
+
+        public Task UiSetFocus(bool @gained) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_ui_set_focus",
+                    Arguments = GetRequestArguments(@gained),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deactivates UI events on the channel.
+        /// </para>
+        /// </summary>
+        public Task UiDetach() =>
+            SendAndReceive(
+                new NvimRequest { Method = "nvim_ui_detach", Arguments = GetRequestArguments() }
+            );
+
+        public Task UiTryResize(long @width, long @height) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_ui_try_resize",
+                    Arguments = GetRequestArguments(@width, @height),
+                }
+            );
+
+        public Task UiSetOption(string @name, object @value) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_ui_set_option",
+                    Arguments = GetRequestArguments(@name, @value),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Tell Nvim to resize a grid. Triggers a grid_resize event with the requested grid size or the maximum size if it exceeds size limits.
+        /// </para>
+        /// </summary>
+        /// <param name="grid">
+        /// <para>
+        /// The handle of the grid to be changed.
+        /// </para>
+        /// </param>
+        /// <param name="width">
+        /// <para>
+        /// The new requested width.
+        /// </para>
+        /// </param>
+        /// <param name="height">
+        /// <para>
+        /// The new requested height.
+        /// </para>
+        /// </param>
+        public Task UiTryResizeGrid(long @grid, long @width, long @height) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_ui_try_resize_grid",
+                    Arguments = GetRequestArguments(@grid, @width, @height),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Tells Nvim the number of elements displaying in the popupmenu, to decide [&lt;PageUp&gt;] and [&lt;PageDown&gt;] movement.
+        /// </para>
+        /// </summary>
+        /// <param name="height">
+        /// <para>
+        /// Popupmenu height, must be greater than zero.
+        /// </para>
+        /// </param>
+        public Task UiPumSetHeight(long @height) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_ui_pum_set_height",
+                    Arguments = GetRequestArguments(@height),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Tells Nvim the geometry of the popupmenu, to align floating windows with an external popup menu.
+        /// </para>
+        /// </summary>
+        /// <param name="width">
+        /// <para>
+        /// Popupmenu width.
+        /// </para>
+        /// </param>
+        /// <param name="height">
+        /// <para>
+        /// Popupmenu height.
+        /// </para>
+        /// </param>
+        /// <param name="row">
+        /// <para>
+        /// Popupmenu row.
+        /// </para>
+        /// </param>
+        /// <param name="col">
+        /// <para>
+        /// Popupmenu height.
+        /// </para>
+        /// </param>
+        public Task UiPumSetBounds(double @width, double @height, double @row, double @col) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_ui_pum_set_bounds",
+                    Arguments = GetRequestArguments(@width, @height, @row, @col),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sends arbitrary data to a UI. Use this instead of |nvim_chan_send()| or
+        /// </para>
+        /// </summary>
+        /// <param name="content">
+        /// <para>
+        /// Content to write to the TTY
+        /// </para>
+        /// </param>
+        public Task UiSend(string @content) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_ui_send",
+                    Arguments = GetRequestArguments(@content),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets a highlight group by name
+        /// </para>
+        /// </summary>
+        public Task<long> GetHlIdByName(string @name) =>
+            SendAndReceive<long>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_hl_id_by_name",
+                    Arguments = GetRequestArguments(@name),
+                }
+            );
+
+        public Task<IDictionary> GetHl(long @nsId, IDictionary @opts) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_hl",
+                    Arguments = GetRequestArguments(@nsId, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets a highlight group. By default, replaces the entire definition (e.g.
+        /// </para>
+        /// </summary>
+        /// <param name="nsId">
+        /// <para>
+        /// Namespace id for this highlight |nvim_create_namespace()|. Use 0 to set a highlight group globally |:highlight|. Highlights from non-global namespaces are not active by default, use |nvim_set_hl_ns()| or |nvim_win_set_hl_ns()| to activate them.
+        /// </para>
+        /// </param>
+        /// <param name="name">
+        /// <para>
+        /// Highlight group name, e.g. &quot;ErrorMsg&quot;
+        /// </para>
+        /// </param>
+        /// <param name="val">
+        /// <para>
+        /// Highlight definition map, accepts the following keys:
+        /// </para>
+        /// </param>
+        /// <remarks>
+        /// The fg and bg keys also accept the string values &quot;fg&quot; or &quot;bg&quot; which act as aliases to the corresponding foreground and background values of the Normal group. If the Normal group has not been defined, using these values results in an error.
+        /// </remarks>
+        public Task SetHl(long @nsId, string @name, IDictionary @val) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_hl",
+                    Arguments = GetRequestArguments(@nsId, @name, @val),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the active highlight namespace.
+        /// </para>
+        /// </summary>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Namespace id, or -1
+        /// </para>
+        /// </returns>
+        public Task<long> GetHlNs(IDictionary @opts) =>
+            SendAndReceive<long>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_hl_ns",
+                    Arguments = GetRequestArguments(@opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Set active namespace for highlights defined with |nvim_set_hl()|. This can be set for a single window, see |nvim_win_set_hl_ns()|.
+        /// </para>
+        /// </summary>
+        /// <param name="nsId">
+        /// <para>
+        /// the namespace to use
+        /// </para>
+        /// </param>
+        public Task SetHlNs(long @nsId) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_hl_ns",
+                    Arguments = GetRequestArguments(@nsId),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Set active namespace for highlights defined with |nvim_set_hl()| while redrawing.
+        /// </para>
+        /// </summary>
+        /// <param name="nsId">
+        /// <para>
+        /// the namespace to activate
+        /// </para>
+        /// </param>
+        public Task SetHlNsFast(long @nsId) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_hl_ns_fast",
+                    Arguments = GetRequestArguments(@nsId),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sends input-keys to Nvim, subject to various quirks controlled by
+        /// </para>
+        /// </summary>
+        /// <param name="keys">
+        /// <para>
+        /// to be typed
+        /// </para>
+        /// </param>
+        /// <param name="mode">
+        /// <para>
+        /// behavior flags, see |feedkeys()|
+        /// </para>
+        /// </param>
+        /// <param name="escapeKs">
+        /// <para>
+        /// If true, escape K_SPECIAL bytes in
+        /// </para>
+        /// </param>
+        public Task Feedkeys(string @keys, string @mode, bool @escapeKs) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_feedkeys",
+                    Arguments = GetRequestArguments(@keys, @mode, @escapeKs),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Queues raw user-input. Unlike |nvim_feedkeys()|, this uses a low-level input buffer and the call is non-blocking (input is processed asynchronously by the eventloop).
+        /// </para>
+        /// </summary>
+        /// <param name="keys">
+        /// <para>
+        /// to be typed
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Number of bytes actually written (can be fewer than requested if the buffer becomes full).
+        /// </para>
+        /// </returns>
+        /// <remarks>
+        /// |keycodes| like [&lt;CR&gt;] are translated, so &quot;&lt;&quot; is special. To input a literal &quot;&lt;&quot;, send [&lt;LT&gt;].
+        /// </remarks>
+        public Task<long> Input(string @keys) =>
+            SendAndReceive<long>(
+                new NvimRequest { Method = "nvim_input", Arguments = GetRequestArguments(@keys) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Send mouse event from GUI.
+        /// </para>
+        /// </summary>
+        /// <param name="button">
+        /// <para>
+        /// Mouse button: one of &quot;left&quot;, &quot;right&quot;, &quot;middle&quot;, &quot;wheel&quot;, &quot;move&quot;, &quot;x1&quot;, &quot;x2&quot;.
+        /// </para>
+        /// </param>
+        /// <param name="action">
+        /// <para>
+        /// For ordinary buttons, one of &quot;press&quot;, &quot;drag&quot;, &quot;release&quot;. For the wheel, one of &quot;up&quot;, &quot;down&quot;, &quot;left&quot;, &quot;right&quot;. Ignored for &quot;move&quot;.
+        /// </para>
+        /// </param>
+        /// <param name="modifier">
+        /// <para>
+        /// String of modifiers each represented by a single char. The same specifiers are used as for a key press, except that the &quot;-&quot; separator is optional, so &quot;C-A-&quot;, &quot;c-a&quot; and &quot;CA&quot; can all be used to specify Ctrl+Alt+click.
+        /// </para>
+        /// </param>
+        /// <param name="grid">
+        /// <para>
+        /// Grid number (used by |ui-multigrid| client), or 0 to let Nvim decide positioning of windows. For more information, see [dev-ui-multigrid]
+        /// </para>
+        /// </param>
+        /// <param name="row">
+        /// <para>
+        /// Mouse row-position (zero-based, like redraw events)
+        /// </para>
+        /// </param>
+        /// <param name="col">
+        /// <para>
+        /// Mouse column-position (zero-based, like redraw events)
+        /// </para>
+        /// </param>
+        /// <remarks>
+        /// Currently this doesn&apos;t support &quot;scripting&quot; multiple mouse events by calling it multiple times in a loop: the intermediate mouse positions will be ignored. It should be used to implement real-time mouse input in a GUI. The deprecated pseudokey form (&lt;LeftMouse&gt;&lt;col,row&gt;) of |nvim_input()| has the same limitation.
+        /// </remarks>
+        public Task InputMouse(
+            string @button,
+            string @action,
+            string @modifier,
+            long @grid,
+            long @row,
+            long @col
+        ) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_input_mouse",
+                    Arguments = GetRequestArguments(@button, @action, @modifier, @grid, @row, @col),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Replaces terminal codes and |keycodes| ([&lt;CR&gt;], [&lt;Esc&gt;], ...) in a string with the internal representation.
+        /// </para>
+        /// </summary>
+        /// <param name="str">
+        /// <para>
+        /// String to be converted.
+        /// </para>
+        /// </param>
+        /// <param name="fromPart">
+        /// <para>
+        /// Legacy Vim parameter. Usually true.
+        /// </para>
+        /// </param>
+        /// <param name="doLt">
+        /// <para>
+        /// Also translate [&lt;lt&gt;]. Ignored if
+        /// </para>
+        /// </param>
+        /// <param name="special">
+        /// <para>
+        /// Replace |keycodes|, e.g. [&lt;CR&gt;] becomes a &quot;\r&quot; char.
+        /// </para>
+        /// </param>
+        /// <remarks>
+        /// Lua can use |vim.keycode()| instead.
+        /// </remarks>
+        public Task<string> ReplaceTermcodes(
+            string @str,
+            bool @fromPart,
+            bool @doLt,
+            bool @special
+        ) =>
+            SendAndReceive<string>(
+                new NvimRequest
+                {
+                    Method = "nvim_replace_termcodes",
+                    Arguments = GetRequestArguments(@str, @fromPart, @doLt, @special),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Executes Lua code. Arguments are available as
+        /// </para>
+        /// </summary>
+        /// <param name="code">
+        /// <para>
+        /// Lua code to execute.
+        /// </para>
+        /// </param>
+        /// <param name="args">
+        /// <para>
+        /// Arguments to the Lua code.
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Value returned by the Lua code (if any), or NIL.
+        /// </para>
+        /// </returns>
+        public Task<object> ExecLua(string @code, object[] @args) =>
+            SendAndReceive<object>(
+                new NvimRequest
+                {
+                    Method = "nvim_exec_lua",
+                    Arguments = GetRequestArguments(@code, @args),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Calculates the number of display cells occupied by
+        /// </para>
+        /// </summary>
+        /// <param name="text">
+        /// <para>
+        /// Some text
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Number of cells
+        /// </para>
+        /// </returns>
+        public Task<long> Strwidth(string @text) =>
+            SendAndReceive<long>(
+                new NvimRequest { Method = "nvim_strwidth", Arguments = GetRequestArguments(@text) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the paths contained in |runtime-search-path|.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// List of paths
+        /// </para>
+        /// </returns>
+        public Task<object[]> ListRuntimePaths() =>
+            SendAndReceive<object[]>(
+                new NvimRequest
+                {
+                    Method = "nvim_list_runtime_paths",
+                    Arguments = GetRequestArguments(),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Finds files in runtime directories, in &apos;runtimepath&apos; order.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// pattern of files to search for
+        /// </para>
+        /// </param>
+        /// <param name="all">
+        /// <para>
+        /// whether to return all matches or only the first
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// list of absolute paths to the found files
+        /// </para>
+        /// </returns>
+        public Task<object[]> GetRuntimeFile(string @name, bool @all) =>
+            SendAndReceive<object[]>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_runtime_file",
+                    Arguments = GetRequestArguments(@name, @all),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Changes the global working directory.
+        /// </para>
+        /// </summary>
+        /// <param name="dir">
+        /// <para>
+        /// Directory path
+        /// </para>
+        /// </param>
+        public Task SetCurrentDir(string @dir) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_current_dir",
+                    Arguments = GetRequestArguments(@dir),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the current line.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// Current line string
+        /// </para>
+        /// </returns>
+        public Task<string> GetCurrentLine() =>
+            SendAndReceive<string>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_current_line",
+                    Arguments = GetRequestArguments(),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets the text on the current line.
+        /// </para>
+        /// </summary>
+        /// <param name="line">
+        /// <para>
+        /// Line contents
+        /// </para>
+        /// </param>
+        public Task SetCurrentLine(string @line) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_current_line",
+                    Arguments = GetRequestArguments(@line),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deletes the current line.
+        /// </para>
+        /// </summary>
+        public Task DelCurrentLine() =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_del_current_line",
+                    Arguments = GetRequestArguments(),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets a global (g:) variable.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Variable name
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Variable value
+        /// </para>
+        /// </returns>
+        public Task<object> GetVar(string @name) =>
+            SendAndReceive<object>(
+                new NvimRequest { Method = "nvim_get_var", Arguments = GetRequestArguments(@name) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets a global (g:) variable.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Variable name
+        /// </para>
+        /// </param>
+        /// <param name="value">
+        /// <para>
+        /// Variable value
+        /// </para>
+        /// </param>
+        public Task SetVar(string @name, object @value) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_var",
+                    Arguments = GetRequestArguments(@name, @value),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Removes a global (g:) variable.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Variable name
+        /// </para>
+        /// </param>
+        public Task DelVar(string @name) =>
+            SendAndReceive(
+                new NvimRequest { Method = "nvim_del_var", Arguments = GetRequestArguments(@name) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets a v: variable.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Variable name
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Variable value
+        /// </para>
+        /// </returns>
+        public Task<object> GetVvar(string @name) =>
+            SendAndReceive<object>(
+                new NvimRequest { Method = "nvim_get_vvar", Arguments = GetRequestArguments(@name) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets a v: variable, if it is not readonly.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Variable name
+        /// </para>
+        /// </param>
+        /// <param name="value">
+        /// <para>
+        /// Variable value
+        /// </para>
+        /// </param>
+        public Task SetVvar(string @name, object @value) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_vvar",
+                    Arguments = GetRequestArguments(@name, @value),
+                }
+            );
+
+        public Task<object> Echo(object[] @chunks, bool @history, IDictionary @opts) =>
+            SendAndReceive<object>(
+                new NvimRequest
+                {
+                    Method = "nvim_echo",
+                    Arguments = GetRequestArguments(@chunks, @history, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the current list of buffers.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// List of buffer ids
+        /// </para>
+        /// </returns>
+        public Task<object[]> ListBufs() =>
+            SendAndReceive<object[]>(
+                new NvimRequest { Method = "nvim_list_bufs", Arguments = GetRequestArguments() }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the current buffer.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// Buffer id
+        /// </para>
+        /// </returns>
+        public Task<NvimBuffer> GetCurrentBuf() =>
+            SendAndReceive<NvimBuffer>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_current_buf",
+                    Arguments = GetRequestArguments(),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets the current window&apos;s buffer to
+        /// </para>
+        /// </summary>
+        /// <param name="buf">
+        /// <para>
+        /// Buffer id
+        /// </para>
+        /// </param>
+        public Task SetCurrentBuf(NvimBuffer @buf) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_current_buf",
+                    Arguments = GetRequestArguments(@buf),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the current list of all |window-ID|s in all tabpages.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// List of |window-ID|s
+        /// </para>
+        /// </returns>
+        public Task<object[]> ListWins() =>
+            SendAndReceive<object[]>(
+                new NvimRequest { Method = "nvim_list_wins", Arguments = GetRequestArguments() }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the current window.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// |window-ID|
+        /// </para>
+        /// </returns>
+        public Task<NvimWindow> GetCurrentWin() =>
+            SendAndReceive<NvimWindow>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_current_win",
+                    Arguments = GetRequestArguments(),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Navigates to the given window (and tabpage, implicitly).
+        /// </para>
+        /// </summary>
+        /// <param name="win">
+        /// <para>
+        /// |window-ID| to focus
+        /// </para>
+        /// </param>
+        public Task SetCurrentWin(NvimWindow @win) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_current_win",
+                    Arguments = GetRequestArguments(@win),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Creates a new, empty, unnamed buffer.
+        /// </para>
+        /// </summary>
+        /// <param name="listed">
+        /// <para>
+        /// Sets &apos;buflisted&apos;
+        /// </para>
+        /// </param>
+        /// <param name="scratch">
+        /// <para>
+        /// Creates a &quot;throwaway&quot; |scratch-buffer| for temporary work (always &apos;nomodified&apos;). Also sets &apos;nomodeline&apos; on the buffer.
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Buffer id, or 0 on error
+        /// </para>
+        /// </returns>
+        public Task<NvimBuffer> CreateBuf(bool @listed, bool @scratch) =>
+            SendAndReceive<NvimBuffer>(
+                new NvimRequest
+                {
+                    Method = "nvim_create_buf",
+                    Arguments = GetRequestArguments(@listed, @scratch),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Open a terminal instance in a buffer
+        /// </para>
+        /// </summary>
+        /// <param name="buf">
+        /// <para>
+        /// Buffer to use. Buffer contents (if any) will be written to the PTY.
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters.
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Channel id, or 0 on error
+        /// </para>
+        /// </returns>
+        public Task<long> OpenTerm(NvimBuffer @buf, IDictionary @opts) =>
+            SendAndReceive<long>(
+                new NvimRequest
+                {
+                    Method = "nvim_open_term",
+                    Arguments = GetRequestArguments(@buf, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sends raw data to channel
+        /// </para>
+        /// </summary>
+        /// <param name="chan">
+        /// <para>
+        /// Channel id
+        /// </para>
+        /// </param>
+        /// <param name="data">
+        /// <para>
+        /// Data to write. 8-bit clean: may contain NUL bytes.
+        /// </para>
+        /// </param>
+        public Task ChanSend(long @chan, string @data) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_chan_send",
+                    Arguments = GetRequestArguments(@chan, @data),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the current list of |tab-ID|s.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// List of |tab-ID|s
+        /// </para>
+        /// </returns>
+        public Task<object[]> ListTabpages() =>
+            SendAndReceive<object[]>(
+                new NvimRequest { Method = "nvim_list_tabpages", Arguments = GetRequestArguments() }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the current tabpage.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// |tab-ID|
+        /// </para>
+        /// </returns>
+        public Task<NvimTabpage> GetCurrentTabpage() =>
+            SendAndReceive<NvimTabpage>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_current_tabpage",
+                    Arguments = GetRequestArguments(),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets the current tabpage.
+        /// </para>
+        /// </summary>
+        /// <param name="tabpage">
+        /// <para>
+        /// |tab-ID| to focus
+        /// </para>
+        /// </param>
+        public Task SetCurrentTabpage(NvimTabpage @tabpage) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_current_tabpage",
+                    Arguments = GetRequestArguments(@tabpage),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Pastes at cursor (in any mode), and sets &quot;redo&quot; so dot (|.|) will repeat the input. UIs call this to implement &quot;paste&quot;, but it&apos;s also intended for use by scripts to input large, dot-repeatable blocks of text (as opposed to |nvim_input()| which is subject to mappings/events and is thus much slower).
+        /// </para>
+        /// </summary>
+        /// <param name="data">
+        /// <para>
+        /// Multiline input. Lines break at LF (&quot;\n&quot;). May be binary (containing NUL bytes).
+        /// </para>
+        /// </param>
+        /// <param name="crlf">
+        /// <para>
+        /// Also break lines at CR and CRLF.
+        /// </para>
+        /// </param>
+        /// <param name="phase">
+        /// <para>
+        /// -1: paste in a single call (i.e. without streaming). To &quot;stream&quot; a paste, call
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// <list type="bullet">
+        /// <item><description>
+        /// true: Client may continue pasting.
+        /// </description></item>
+        /// </list>
+        /// </para>
+        /// </returns>
+        public Task<bool> Paste(string @data, bool @crlf, long @phase) =>
+            SendAndReceive<bool>(
+                new NvimRequest
+                {
+                    Method = "nvim_paste",
+                    Arguments = GetRequestArguments(@data, @crlf, @phase),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Puts text at cursor, in any mode. For dot-repeatable input, use |nvim_paste()|.
+        /// </para>
+        /// </summary>
+        /// <param name="lines">
+        /// <para>
+        /// |readfile()|-style list of lines. |channel-lines|
+        /// </para>
+        /// </param>
+        /// <param name="type">
+        /// <para>
+        /// Edit behavior: any |getregtype()| result, or:
+        /// </para>
+        /// </param>
+        /// <param name="after">
+        /// <para>
+        /// If true insert after cursor (like |p|), or before (like |P|).
+        /// </para>
+        /// </param>
+        /// <param name="follow">
+        /// <para>
+        /// If true place cursor at end of inserted text.
+        /// </para>
+        /// </param>
+        public Task Put(object[] @lines, string @type, bool @after, bool @follow) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_put",
+                    Arguments = GetRequestArguments(@lines, @type, @after, @follow),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Returns the 24-bit RGB value of a |nvim_get_color_map()| color name or &quot;#rrggbb&quot; hexadecimal string.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Color name or &quot;#rrggbb&quot; string
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// 24-bit RGB value, or -1 for invalid argument.
+        /// </para>
+        /// </returns>
+        public Task<long> GetColorByName(string @name) =>
+            SendAndReceive<long>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_color_by_name",
+                    Arguments = GetRequestArguments(@name),
+                }
+            );
+
+        public Task<IDictionary> GetColorMap() =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest { Method = "nvim_get_color_map", Arguments = GetRequestArguments() }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets a map of the current editor state.
+        /// </para>
+        /// </summary>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters.
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// map of global |context|.
+        /// </para>
+        /// </returns>
+        public Task<IDictionary> GetContext(IDictionary @opts) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_context",
+                    Arguments = GetRequestArguments(@opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets the current editor state from the given |context| map.
+        /// </para>
+        /// </summary>
+        /// <param name="dict">
+        /// <para>
+        /// |Context| map.
+        /// </para>
+        /// </param>
+        public Task<object> LoadContext(IDictionary @dict) =>
+            SendAndReceive<object>(
+                new NvimRequest
+                {
+                    Method = "nvim_load_context",
+                    Arguments = GetRequestArguments(@dict),
+                }
+            );
+
+        public Task<IDictionary> GetMode() =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest { Method = "nvim_get_mode", Arguments = GetRequestArguments() }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets a list of global (non-buffer-local) |mapping| definitions.
+        /// </para>
+        /// </summary>
+        /// <param name="mode">
+        /// <para>
+        /// Mode short-name (&quot;n&quot;, &quot;i&quot;, &quot;v&quot;, ...)
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Array of |maparg()|-like dictionaries describing mappings. The &quot;buf&quot; key is always zero.
+        /// </para>
+        /// </returns>
+        public Task<object[]> GetKeymap(string @mode) =>
+            SendAndReceive<object[]>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_keymap",
+                    Arguments = GetRequestArguments(@mode),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Sets a global |mapping| for the given mode.
+        /// </para>
+        /// </summary>
+        /// <param name="mode">
+        /// <para>
+        /// Mode short-name (map command prefix: &quot;n&quot;, &quot;i&quot;, &quot;v&quot;, &quot;x&quot;, …) or &quot;!&quot; for |:map!|, or empty string for |:map|. &quot;ia&quot;, &quot;ca&quot; or &quot;!a&quot; for abbreviation in Insert mode, Cmdline mode, or both, respectively
+        /// </para>
+        /// </param>
+        /// <param name="lhs">
+        /// <para>
+        /// Left-hand-side |{lhs}| of the mapping.
+        /// </para>
+        /// </param>
+        /// <param name="rhs">
+        /// <para>
+        /// Right-hand-side |{rhs}| of the mapping.
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters map: Accepts all |:map-arguments| as keys except [&lt;buffer&gt;], values are booleans (default false). Also:
+        /// </para>
+        /// </param>
+        public Task SetKeymap(string @mode, string @lhs, string @rhs, IDictionary @opts) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_keymap",
+                    Arguments = GetRequestArguments(@mode, @lhs, @rhs, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Unmaps a global |mapping| for the given mode.
+        /// </para>
+        /// </summary>
+        public Task DelKeymap(string @mode, string @lhs) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_del_keymap",
+                    Arguments = GetRequestArguments(@mode, @lhs),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Returns a 2-tuple (Array), where item 0 is the current channel id and item 1 is the |api-metadata| map (
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// 2-tuple
+        /// </para>
+        /// </returns>
+        public Task<object[]> GetApiInfo() =>
+            SendAndReceive<object[]>(
+                new NvimRequest { Method = "nvim_get_api_info", Arguments = GetRequestArguments() }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Self-identifies the client, and sets optional flags on the channel. Defines the
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Client short-name. Sets the
+        /// </para>
+        /// </param>
+        /// <param name="version">
+        /// <para>
+        /// Dict
+        /// </para>
+        /// </param>
+        /// <param name="type">
+        /// <para>
+        /// Must be one of the following values. Client libraries should default to &quot;remote&quot; unless overridden by the user.
+        /// </para>
+        /// </param>
+        /// <param name="methods">
+        /// <para>
+        /// Builtin methods in the client. For a host, this does not include plugin methods which will be discovered later. The key should be the method name, the values are dicts with these (optional) keys (more keys may be added in future versions of Nvim, thus unknown keys are ignored. Clients must only use keys defined in this or later versions of Nvim):
+        /// </para>
+        /// </param>
+        /// <param name="attributes">
+        /// <para>
+        /// Arbitrary string:string map of informal client properties. Suggested keys:
+        /// </para>
+        /// </param>
+        public Task SetClientInfo(
+            string @name,
+            IDictionary @version,
+            string @type,
+            IDictionary @methods,
+            IDictionary @attributes
+        ) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_set_client_info",
+                    Arguments = GetRequestArguments(@name, @version, @type, @methods, @attributes),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets information about a channel.
+        /// </para>
+        /// </summary>
+        /// <param name="chan">
+        /// <para>
+        /// channel_id, or 0 for current channel
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Channel info dict with these keys:
+        /// </para>
+        /// </returns>
+        public Task<IDictionary> GetChanInfo(long @chan) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_chan_info",
+                    Arguments = GetRequestArguments(@chan),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Get information about all open channels.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// Array of Dictionaries, each describing a channel with the format specified at |nvim_get_chan_info()|.
+        /// </para>
+        /// </returns>
+        public Task<object[]> ListChans() =>
+            SendAndReceive<object[]>(
+                new NvimRequest { Method = "nvim_list_chans", Arguments = GetRequestArguments() }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets a list of dictionaries representing attached UIs.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// Array of UI dictionaries, each with these keys:
+        /// </para>
+        /// </returns>
+        public Task<object[]> ListUis() =>
+            SendAndReceive<object[]>(
+                new NvimRequest { Method = "nvim_list_uis", Arguments = GetRequestArguments() }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets the immediate children of process
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// Array of child process ids, empty if process not found.
+        /// </para>
+        /// </returns>
+        public Task<object[]> GetProcChildren(long @pid) =>
+            SendAndReceive<object[]>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_proc_children",
+                    Arguments = GetRequestArguments(@pid),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Gets info describing process
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// <para>
+        /// Map of process properties, or NIL if process not found.
+        /// </para>
+        /// </returns>
+        public Task<object> GetProc(long @pid) =>
+            SendAndReceive<object>(
+                new NvimRequest { Method = "nvim_get_proc", Arguments = GetRequestArguments(@pid) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Selects an item in the completion popup menu.
+        /// </para>
+        /// </summary>
+        /// <param name="item">
+        /// <para>
+        /// Index (zero-based) of the item to select. Value of -1 selects nothing and restores the original text.
+        /// </para>
+        /// </param>
+        /// <param name="insert">
+        /// <para>
+        /// For |ins-completion|, whether the selection should be inserted in the buffer. Ignored for |cmdline-completion|.
+        /// </para>
+        /// </param>
+        /// <param name="finish">
+        /// <para>
+        /// Finish the completion and dismiss the popup menu. Implies {insert}.
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters. Reserved for future use.
+        /// </para>
+        /// </param>
+        public Task SelectPopupmenuItem(
+            long @item,
+            bool @insert,
+            bool @finish,
+            IDictionary @opts
+        ) =>
+            SendAndReceive(
+                new NvimRequest
+                {
+                    Method = "nvim_select_popupmenu_item",
+                    Arguments = GetRequestArguments(@item, @insert, @finish, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Deletes an uppercase/file named mark. See |mark-motions|.
+        /// </para>
+        /// </summary>
+        /// <param name="name">
+        /// <para>
+        /// Mark name
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// true if the mark was deleted, else false.
+        /// </para>
+        /// </returns>
+        /// <remarks>
+        /// Lowercase name (or other buffer-local mark) is an error.
+        /// </remarks>
+        public Task<bool> DelMark(string @name) =>
+            SendAndReceive<bool>(
+                new NvimRequest { Method = "nvim_del_mark", Arguments = GetRequestArguments(@name) }
+            );
+
+        public Task<object[]> GetMark(string @name, IDictionary @opts) =>
+            SendAndReceive<object[]>(
+                new NvimRequest
+                {
+                    Method = "nvim_get_mark",
+                    Arguments = GetRequestArguments(@name, @opts),
+                }
+            );
+
+        public Task<IDictionary> EvalStatusline(string @str, IDictionary @opts) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_eval_statusline",
+                    Arguments = GetRequestArguments(@str, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Executes Vimscript (multiline block of Ex commands), like anonymous |:source|.
+        /// </para>
+        /// </summary>
+        /// <param name="src">
+        /// <para>
+        /// Vimscript code
+        /// </para>
+        /// </param>
+        /// <param name="opts">
+        /// <para>
+        /// Optional parameters.
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Dict
+        /// </para>
+        /// </returns>
+        public Task<IDictionary> Exec2(string @src, IDictionary @opts) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_exec2",
+                    Arguments = GetRequestArguments(@src, @opts),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Executes an Ex command.
+        /// </para>
+        /// </summary>
+        /// <param name="cmd">
+        /// <para>
+        /// Ex command string
+        /// </para>
+        /// </param>
+        public Task Command(string @cmd) =>
+            SendAndReceive(
+                new NvimRequest { Method = "nvim_command", Arguments = GetRequestArguments(@cmd) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Evaluates a Vimscript |expression|. Dicts and Lists are recursively expanded.
+        /// </para>
+        /// </summary>
+        /// <param name="expr">
+        /// <para>
+        /// Vimscript expression string
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Evaluation result or expanded object
+        /// </para>
+        /// </returns>
+        public Task<object> Eval(string @expr) =>
+            SendAndReceive<object>(
+                new NvimRequest { Method = "nvim_eval", Arguments = GetRequestArguments(@expr) }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Calls a Vimscript function with the given arguments.
+        /// </para>
+        /// </summary>
+        /// <param name="fn">
+        /// <para>
+        /// Function to call
+        /// </para>
+        /// </param>
+        /// <param name="args">
+        /// <para>
+        /// Function arguments packed in an Array
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Result of the function call
+        /// </para>
+        /// </returns>
+        public Task<object> CallFunction(string @fn, object[] @args) =>
+            SendAndReceive<object>(
+                new NvimRequest
+                {
+                    Method = "nvim_call_function",
+                    Arguments = GetRequestArguments(@fn, @args),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Calls a Vimscript |Dictionary-function| with the given arguments.
+        /// </para>
+        /// </summary>
+        /// <param name="dict">
+        /// <para>
+        /// Dict
+        /// </para>
+        /// </param>
+        /// <param name="fn">
+        /// <para>
+        /// Name of the function defined on the Vimscript dict
+        /// </para>
+        /// </param>
+        /// <param name="args">
+        /// <para>
+        /// Function arguments packed in an Array
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// Result of the function call
+        /// </para>
+        /// </returns>
+        public Task<object> CallDictFunction(object @dict, string @fn, object[] @args) =>
+            SendAndReceive<object>(
+                new NvimRequest
+                {
+                    Method = "nvim_call_dict_function",
+                    Arguments = GetRequestArguments(@dict, @fn, @args),
+                }
+            );
+
+        public Task<IDictionary> ParseExpression(string @expr, string @flags, bool @hl) =>
+            SendAndReceive<IDictionary>(
+                new NvimRequest
+                {
+                    Method = "nvim_parse_expression",
+                    Arguments = GetRequestArguments(@expr, @flags, @hl),
+                }
+            );
+
+        /// <summary>
+        /// <para>
+        /// Opens a new split window, floating window, or external window.
+        /// </para>
+        /// </summary>
+        /// <param name="buf">
+        /// <para>
+        /// Buffer to display, or 0 for current buffer
+        /// </para>
+        /// </param>
+        /// <param name="enter">
+        /// <para>
+        /// Enter the window (make it the current window)
+        /// </para>
+        /// </param>
+        /// <param name="config">
+        /// <para>
+        /// Map defining the window configuration. Keys:
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// |window-ID|, or 0 on error
+        /// </para>
+        /// </returns>
+        public Task<NvimWindow> OpenWin(NvimBuffer @buf, bool @enter, IDictionary @config) =>
+            SendAndReceive<NvimWindow>(
+                new NvimRequest
+                {
+                    Method = "nvim_open_win",
+                    Arguments = GetRequestArguments(@buf, @enter, @config),
+                }
+            );
+
+        public class NvimBuffer
+        {
+            private readonly NvimAPI _api;
+            private readonly MessagePackExtendedTypeObject _msgPackExtObj;
+
+            internal NvimBuffer(NvimAPI api, MessagePackExtendedTypeObject msgPackExtObj)
+            {
+                _api = api;
+                _msgPackExtObj = msgPackExtObj;
+            }
+
+            /// <summary>
+            /// <para>
+            /// help
+            /// For more information on buffers, see |buffers|.
+            ///
+            /// Unloaded Buffers: ~
+            ///
+            /// Buffers may be unloaded by the |:bunload| command or the buffer&apos;s
+            /// &apos;bufhidden&apos; option. When a buffer is unloaded its file contents are freed
+            /// from memory and vim cannot operate on the buffer lines until it is reloaded
+            /// (usually by opening the buffer again in a new window). API methods such as
+            /// |nvim_buf_get_lines()| and |nvim_buf_line_count()| will be affected.
+            ///
+            /// You can use |nvim_buf_is_loaded()| or |nvim_buf_line_count()| to check
+            /// whether a buffer is loaded.
+            ///
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// Line count, or 0 for unloaded buffer. |api-buffer|
+            /// </para>
+            /// </returns>
+            public Task<long> LineCount() =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_line_count",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Activates |api-buffer-updates| events on a channel, or as Lua callbacks.
+            /// </para>
+            /// </summary>
+            /// <param name="sendBuffer">
+            /// <para>
+            /// True if the initial notification should contain the whole buffer: first notification will be
+            /// </para>
+            /// </param>
+            /// <param name="opts">
+            /// <para>
+            /// Optional parameters.
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// False if attach failed (invalid parameter, or buffer isn&apos;t loaded); otherwise True.
+            /// </para>
+            /// </returns>
+            public Task<bool> Attach(bool @sendBuffer, IDictionary @opts) =>
+                _api.SendAndReceive<bool>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_attach",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @sendBuffer, @opts),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Deactivates buffer-update events on the channel.
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// False if detach failed (because the buffer isn&apos;t loaded); otherwise True.
+            /// </para>
+            /// </returns>
+            public Task<bool> Detach() =>
+                _api.SendAndReceive<bool>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_detach",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets a line-range from the buffer.
+            /// </para>
+            /// </summary>
+            /// <param name="start">
+            /// <para>
+            /// First line index
+            /// </para>
+            /// </param>
+            /// <param name="end">
+            /// <para>
+            /// Last line index, exclusive
+            /// </para>
+            /// </param>
+            /// <param name="strictIndexing">
+            /// <para>
+            /// Whether out-of-bounds should be an error.
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Array of lines, or empty array for unloaded buffer.
+            /// </para>
+            /// </returns>
+            public Task<object[]> GetLines(long @start, long @end, bool @strictIndexing) =>
+                _api.SendAndReceive<object[]>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_lines",
+                        Arguments = GetRequestArguments(
+                            _msgPackExtObj,
+                            @start,
+                            @end,
+                            @strictIndexing
+                        ),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets (replaces) a line-range in the buffer.
+            /// </para>
+            /// </summary>
+            /// <param name="start">
+            /// <para>
+            /// First line index
+            /// </para>
+            /// </param>
+            /// <param name="end">
+            /// <para>
+            /// Last line index, exclusive
+            /// </para>
+            /// </param>
+            /// <param name="strictIndexing">
+            /// <para>
+            /// Whether out-of-bounds should be an error.
+            /// </para>
+            /// </param>
+            /// <param name="replacement">
+            /// <para>
+            /// Array of lines to use as replacement
+            /// </para>
+            /// </param>
+            public Task SetLines(
+                long @start,
+                long @end,
+                bool @strictIndexing,
+                object[] @replacement
+            ) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_set_lines",
+                        Arguments = GetRequestArguments(
+                            _msgPackExtObj,
+                            @start,
+                            @end,
+                            @strictIndexing,
+                            @replacement
+                        ),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets (replaces) a range in the buffer
+            /// </para>
+            /// </summary>
+            /// <param name="startRow">
+            /// <para>
+            /// First line index
+            /// </para>
+            /// </param>
+            /// <param name="startCol">
+            /// <para>
+            /// Starting column (byte offset) on first line
+            /// </para>
+            /// </param>
+            /// <param name="endRow">
+            /// <para>
+            /// Last line index, inclusive
+            /// </para>
+            /// </param>
+            /// <param name="endCol">
+            /// <para>
+            /// Ending column (byte offset) on last line, exclusive
+            /// </para>
+            /// </param>
+            /// <param name="replacement">
+            /// <para>
+            /// Array of lines to use as replacement
+            /// </para>
+            /// </param>
+            /// <remarks>
+            /// Prefer |nvim_buf_set_lines()| (for performance) to add or delete entire lines.
+            /// </remarks>
+            public Task SetText(
+                long @startRow,
+                long @startCol,
+                long @endRow,
+                long @endCol,
+                object[] @replacement
+            ) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_set_text",
+                        Arguments = GetRequestArguments(
+                            _msgPackExtObj,
+                            @startRow,
+                            @startCol,
+                            @endRow,
+                            @endCol,
+                            @replacement
+                        ),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets a range from the buffer (may be partial lines, unlike |nvim_buf_get_lines()|).
+            /// </para>
+            /// </summary>
+            /// <param name="startRow">
+            /// <para>
+            /// First line index
+            /// </para>
+            /// </param>
+            /// <param name="startCol">
+            /// <para>
+            /// Starting column (byte offset) on first line
+            /// </para>
+            /// </param>
+            /// <param name="endRow">
+            /// <para>
+            /// Last line index, inclusive
+            /// </para>
+            /// </param>
+            /// <param name="endCol">
+            /// <para>
+            /// Ending column (byte offset) on last line, exclusive
+            /// </para>
+            /// </param>
+            /// <param name="opts">
+            /// <para>
+            /// Optional parameters. Currently unused.
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Array of lines, or empty array for unloaded buffer.
+            /// </para>
+            /// </returns>
+            public Task<object[]> GetText(
+                long @startRow,
+                long @startCol,
+                long @endRow,
+                long @endCol,
+                IDictionary @opts
+            ) =>
+                _api.SendAndReceive<object[]>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_text",
+                        Arguments = GetRequestArguments(
+                            _msgPackExtObj,
+                            @startRow,
+                            @startCol,
+                            @endRow,
+                            @endCol,
+                            @opts
+                        ),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Returns the byte offset of a line (0-indexed). |api-indexing|
+            /// </para>
+            /// </summary>
+            /// <param name="index">
+            /// <para>
+            /// Line index
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Integer byte offset, or -1 for unloaded buffer.
+            /// </para>
+            /// </returns>
+            public Task<long> GetOffset(long @index) =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_offset",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @index),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets a buffer-scoped (b:) variable.
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Variable name
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Variable value
+            /// </para>
+            /// </returns>
+            public Task<object> GetVar(string @name) =>
+                _api.SendAndReceive<object>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_var",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets a changed tick of a buffer
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// <c>b:changedtick</c>
+            /// </para>
+            /// </returns>
+            public Task<long> GetChangedtick() =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_changedtick",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets a list of buffer-local |mapping| definitions.
+            /// </para>
+            /// </summary>
+            /// <param name="mode">
+            /// <para>
+            /// Mode short-name (&quot;n&quot;, &quot;i&quot;, &quot;v&quot;, ...)
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Array of |maparg()|-like dictionaries describing mappings. The &quot;buf&quot; key holds the associated buffer id.
+            /// </para>
+            /// </returns>
+            public Task<object[]> GetKeymap(string @mode) =>
+                _api.SendAndReceive<object[]>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_keymap",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @mode),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets a buffer-local |mapping| for the given mode.
+            /// </para>
+            /// </summary>
+            public Task SetKeymap(string @mode, string @lhs, string @rhs, IDictionary @opts) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_set_keymap",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @mode, @lhs, @rhs, @opts),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Unmaps a buffer-local |mapping| for the given mode.
+            /// </para>
+            /// </summary>
+            public Task DelKeymap(string @mode, string @lhs) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_del_keymap",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @mode, @lhs),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets a buffer-scoped (b:) variable
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Variable name
+            /// </para>
+            /// </param>
+            /// <param name="value">
+            /// <para>
+            /// Variable value
+            /// </para>
+            /// </param>
+            public Task SetVar(string @name, object @value) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_set_var",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name, @value),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Removes a buffer-scoped (b:) variable
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Variable name
+            /// </para>
+            /// </param>
+            public Task DelVar(string @name) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_del_var",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the full file name for the buffer
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// Buffer name
+            /// </para>
+            /// </returns>
+            public Task<string> GetName() =>
+                _api.SendAndReceive<string>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_name",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets the full file name for a buffer, like |:file_f|
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Buffer name
+            /// </para>
+            /// </param>
+            public Task SetName(string @name) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_set_name",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Checks if a buffer is valid and loaded. See |api-buffer| for more info about unloaded buffers.
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// true if the buffer is valid and loaded, false otherwise.
+            /// </para>
+            /// </returns>
+            public Task<bool> IsLoaded() =>
+                _api.SendAndReceive<bool>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_is_loaded",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Deletes a buffer and its metadata (like |:bwipeout|).
+            /// </para>
+            /// </summary>
+            /// <param name="opts">
+            /// <para>
+            /// Optional parameters. Keys:
+            /// </para>
+            /// </param>
+            public Task Delete(IDictionary @opts) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_delete",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @opts),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Checks if a buffer is valid.
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// true if the buffer is valid, false otherwise.
+            /// </para>
+            /// </returns>
+            /// <remarks>
+            /// Even if a buffer is valid it may have been unloaded. See |api-buffer| for more info about unloaded buffers.
+            /// </remarks>
+            public Task<bool> IsValid() =>
+                _api.SendAndReceive<bool>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_is_valid",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Deletes a named mark in the buffer. See |mark-motions|.
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Mark name
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// true if the mark was deleted, else false.
+            /// </para>
+            /// </returns>
+            /// <remarks>
+            /// only deletes marks set in the buffer, if the mark is not set in the buffer it will return false.
+            /// </remarks>
+            public Task<bool> DelMark(string @name) =>
+                _api.SendAndReceive<bool>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_del_mark",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets a named mark in the given buffer, all marks are allowed file/uppercase, visual, last change, etc. See |mark-motions|.
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Mark name
+            /// </para>
+            /// </param>
+            /// <param name="line">
+            /// <para>
+            /// Line number
+            /// </para>
+            /// </param>
+            /// <param name="col">
+            /// <para>
+            /// Column/row number
+            /// </para>
+            /// </param>
+            /// <param name="opts">
+            /// <para>
+            /// Optional parameters. Reserved for future use.
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// true if the mark was set, else false.
+            /// </para>
+            /// </returns>
+            /// <remarks>
+            /// Passing 0 as line deletes the mark
+            /// </remarks>
+            public Task<bool> SetMark(string @name, long @line, long @col, IDictionary @opts) =>
+                _api.SendAndReceive<bool>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_set_mark",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name, @line, @col, @opts),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Returns a
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Mark name
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// (row, col) tuple, (0, 0) if the mark is not set, or is an uppercase/file mark set in another buffer.
+            /// </para>
+            /// </returns>
+            public Task<object[]> GetMark(string @name) =>
+                _api.SendAndReceive<object[]>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_mark",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Creates a buffer-local command |user-commands|.
+            /// </para>
+            /// </summary>
+            public Task CreateUserCommand(string @name, object @cmd, IDictionary @opts) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_create_user_command",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name, @cmd, @opts),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Delete a buffer-local user-defined command.
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Name of the command to delete.
+            /// </para>
+            /// </param>
+            public Task DelUserCommand(string @name) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_del_user_command",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            public Task<IDictionary> GetCommands(IDictionary @opts) =>
+                _api.SendAndReceive<IDictionary>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_commands",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @opts),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Clears highlights and virtual text from namespace and range of lines
+            /// </para>
+            /// </summary>
+            /// <param name="nsId">
+            /// <para>
+            /// Namespace to clear, or -1 to clear all.
+            /// </para>
+            /// </param>
+            /// <param name="lineStart">
+            /// <para>
+            /// Start of range of lines to clear
+            /// </para>
+            /// </param>
+            /// <param name="lineEnd">
+            /// <para>
+            /// End of range of lines to clear (exclusive) or -1 to clear to end of file.
+            /// </para>
+            /// </param>
+            public Task ClearHighlight(long @nsId, long @lineStart, long @lineEnd) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_clear_highlight",
+                        Arguments = GetRequestArguments(
+                            _msgPackExtObj,
+                            @nsId,
+                            @lineStart,
+                            @lineEnd
+                        ),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Adds a highlight to buffer.
+            /// </para>
+            /// </summary>
+            /// <param name="nsId">
+            /// <para>
+            /// namespace to use or -1 for ungrouped highlight
+            /// </para>
+            /// </param>
+            /// <param name="hlGroup">
+            /// <para>
+            /// Name of the highlight group to use
+            /// </para>
+            /// </param>
+            /// <param name="line">
+            /// <para>
+            /// Line to highlight (zero-indexed)
+            /// </para>
+            /// </param>
+            /// <param name="colStart">
+            /// <para>
+            /// Start of (byte-indexed) column range to highlight
+            /// </para>
+            /// </param>
+            /// <param name="colEnd">
+            /// <para>
+            /// End of (byte-indexed) column range to highlight, or -1 to highlight to end of line
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// The ns_id that was used
+            /// </para>
+            /// </returns>
+            public Task<long> AddHighlight(
+                long @nsId,
+                string @hlGroup,
+                long @line,
+                long @colStart,
+                long @colEnd
+            ) =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_add_highlight",
+                        Arguments = GetRequestArguments(
+                            _msgPackExtObj,
+                            @nsId,
+                            @hlGroup,
+                            @line,
+                            @colStart,
+                            @colEnd
+                        ),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Set the virtual text (annotation) for a buffer line.
+            /// </para>
+            /// </summary>
+            /// <param name="srcId">
+            /// <para>
+            /// Namespace to use or 0 to create a namespace, or -1 for a ungrouped annotation
+            /// </para>
+            /// </param>
+            /// <param name="line">
+            /// <para>
+            /// Line to annotate with virtual text (zero-indexed)
+            /// </para>
+            /// </param>
+            /// <param name="chunks">
+            /// <para>
+            /// A list of [text, hl_group] arrays, each representing a text chunk with specified highlight.
+            /// </para>
+            /// </param>
+            /// <param name="opts">
+            /// <para>
+            /// Optional parameters. Currently not used.
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// The ns_id that was used
+            /// </para>
+            /// </returns>
+            public Task<long> SetVirtualText(
+                long @srcId,
+                long @line,
+                object[] @chunks,
+                IDictionary @opts
+            ) =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_set_virtual_text",
+                        Arguments = GetRequestArguments(
+                            _msgPackExtObj,
+                            @srcId,
+                            @line,
+                            @chunks,
+                            @opts
+                        ),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets a buffer option value
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Option name
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Option value
+            /// </para>
+            /// </returns>
+            public Task<object> GetOption(string @name) =>
+                _api.SendAndReceive<object>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_option",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets a buffer option value. Passing
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Option name
+            /// </para>
+            /// </param>
+            /// <param name="value">
+            /// <para>
+            /// Option value
+            /// </para>
+            /// </param>
+            public Task SetOption(string @name, object @value) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_set_option",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name, @value),
+                    }
+                );
+
+            public Task<object[]> GetExtmarkById(long @nsId, long @id, IDictionary @opts) =>
+                _api.SendAndReceive<object[]>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_extmark_by_id",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @nsId, @id, @opts),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets |extmarks| in &quot;traversal order&quot; from a |charwise| region defined by buffer positions (inclusive, 0-indexed |api-indexing|).
+            /// </para>
+            /// </summary>
+            /// <param name="nsId">
+            /// <para>
+            /// Namespace id from |nvim_create_namespace()| or -1 for all namespaces
+            /// </para>
+            /// </param>
+            /// <param name="start">
+            /// <para>
+            /// Start of range: a 0-indexed (row, col) or valid extmark id (whose position defines the bound). |api-indexing|
+            /// </para>
+            /// </param>
+            /// <param name="end">
+            /// <para>
+            /// End of range (inclusive): a 0-indexed (row, col) or valid extmark id (whose position defines the bound). |api-indexing|
+            /// </para>
+            /// </param>
+            /// <param name="opts">
+            /// <para>
+            /// Optional parameters. Keys:
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// List of
+            /// </para>
+            /// </returns>
+            public Task<object[]> GetExtmarks(
+                long @nsId,
+                object @start,
+                object @end,
+                IDictionary @opts
+            ) =>
+                _api.SendAndReceive<object[]>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_get_extmarks",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @nsId, @start, @end, @opts),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Creates or updates an |extmark|.
+            /// </para>
+            /// </summary>
+            /// <param name="nsId">
+            /// <para>
+            /// Namespace id from |nvim_create_namespace()|
+            /// </para>
+            /// </param>
+            /// <param name="line">
+            /// <para>
+            /// Line where to place the mark, 0-based. |api-indexing|
+            /// </para>
+            /// </param>
+            /// <param name="col">
+            /// <para>
+            /// Column where to place the mark, 0-based. |api-indexing|
+            /// </para>
+            /// </param>
+            /// <param name="opts">
+            /// <para>
+            /// Optional parameters.
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Id of the created/updated extmark
+            /// </para>
+            /// </returns>
+            public Task<long> SetExtmark(long @nsId, long @line, long @col, IDictionary @opts) =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_set_extmark",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @nsId, @line, @col, @opts),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Removes an |extmark|.
+            /// </para>
+            /// </summary>
+            /// <param name="nsId">
+            /// <para>
+            /// Namespace id from |nvim_create_namespace()|
+            /// </para>
+            /// </param>
+            /// <param name="id">
+            /// <para>
+            /// Extmark id
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// true if the extmark was found, else false
+            /// </para>
+            /// </returns>
+            public Task<bool> DelExtmark(long @nsId, long @id) =>
+                _api.SendAndReceive<bool>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_del_extmark",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @nsId, @id),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Clears |namespace|d objects (highlights, |extmarks|, virtual text) from a region.
+            /// </para>
+            /// </summary>
+            /// <param name="nsId">
+            /// <para>
+            /// Namespace to clear, or -1 to clear all namespaces.
+            /// </para>
+            /// </param>
+            /// <param name="lineStart">
+            /// <para>
+            /// Start of range of lines to clear
+            /// </para>
+            /// </param>
+            /// <param name="lineEnd">
+            /// <para>
+            /// End of range of lines to clear (exclusive) or -1 to clear to end of buffer.
+            /// </para>
+            /// </param>
+            public Task ClearNamespace(long @nsId, long @lineStart, long @lineEnd) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_buf_clear_namespace",
+                        Arguments = GetRequestArguments(
+                            _msgPackExtObj,
+                            @nsId,
+                            @lineStart,
+                            @lineEnd
+                        ),
+                    }
+                );
+        }
+
+        public class NvimWindow
+        {
+            private readonly NvimAPI _api;
+            private readonly MessagePackExtendedTypeObject _msgPackExtObj;
+
+            internal NvimWindow(NvimAPI api, MessagePackExtendedTypeObject msgPackExtObj)
+            {
+                _api = api;
+                _msgPackExtObj = msgPackExtObj;
+            }
+
+            /// <summary>
+            /// <para>
+            /// Gets a window option value
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Option name
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Option value
+            /// </para>
+            /// </returns>
+            public Task<object> GetOption(string @name) =>
+                _api.SendAndReceive<object>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_option",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets a window option value. Passing
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Option name
+            /// </para>
+            /// </param>
+            /// <param name="value">
+            /// <para>
+            /// Option value
+            /// </para>
+            /// </param>
+            public Task SetOption(string @name, object @value) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_set_option",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name, @value),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Reconfigures the layout and properties of a window.
+            /// </para>
+            /// </summary>
+            /// <param name="config">
+            /// <para>
+            /// Map defining the window configuration, see [nvim_open_win()]
+            /// </para>
+            /// </param>
+            public Task SetConfig(IDictionary @config) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_set_config",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @config),
+                    }
+                );
+
+            public Task<IDictionary> GetConfig() =>
+                _api.SendAndReceive<IDictionary>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_config",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the current buffer in a window
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// Buffer id
+            /// </para>
+            /// </returns>
+            public Task<NvimBuffer> GetBuf() =>
+                _api.SendAndReceive<NvimBuffer>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_buf",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets the current buffer in a window.
+            /// </para>
+            /// </summary>
+            /// <param name="buf">
+            /// <para>
+            /// Buffer id
+            /// </para>
+            /// </param>
+            public Task SetBuf(NvimBuffer @buf) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_set_buf",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @buf),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the (1,0)-indexed, buffer-relative cursor position for a given window (different windows showing the same buffer have independent cursor positions). |api-indexing|
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// (row, col) tuple
+            /// </para>
+            /// </returns>
+            public Task<object[]> GetCursor() =>
+                _api.SendAndReceive<object[]>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_cursor",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets the (1,0)-indexed cursor position (byte offset) in the window. |api-indexing| This scrolls the window even if it is not the current one.
+            /// </para>
+            /// </summary>
+            /// <param name="pos">
+            /// <para>
+            /// (row, col) tuple representing the new position
+            /// </para>
+            /// </param>
+            public Task SetCursor(object[] @pos) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_set_cursor",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @pos),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the window height
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// Height as a count of rows
+            /// </para>
+            /// </returns>
+            public Task<long> GetHeight() =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_height",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets the window height.
+            /// </para>
+            /// </summary>
+            /// <param name="height">
+            /// <para>
+            /// Height as a count of rows
+            /// </para>
+            /// </param>
+            public Task SetHeight(long @height) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_set_height",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @height),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the window width
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// Width as a count of columns
+            /// </para>
+            /// </returns>
+            public Task<long> GetWidth() =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_width",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets the window width. This will only succeed if the screen is split vertically.
+            /// </para>
+            /// </summary>
+            /// <param name="width">
+            /// <para>
+            /// Width as a count of columns
+            /// </para>
+            /// </param>
+            public Task SetWidth(long @width) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_set_width",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @width),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets a window-scoped (w:) variable
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Variable name
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Variable value
+            /// </para>
+            /// </returns>
+            public Task<object> GetVar(string @name) =>
+                _api.SendAndReceive<object>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_var",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets a window-scoped (w:) variable
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Variable name
+            /// </para>
+            /// </param>
+            /// <param name="value">
+            /// <para>
+            /// Variable value
+            /// </para>
+            /// </param>
+            public Task SetVar(string @name, object @value) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_set_var",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name, @value),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Removes a window-scoped (w:) variable
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Variable name
+            /// </para>
+            /// </param>
+            public Task DelVar(string @name) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_del_var",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the window position in display cells. First position is zero.
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// (row, col) tuple with the window position
+            /// </para>
+            /// </returns>
+            public Task<object[]> GetPosition() =>
+                _api.SendAndReceive<object[]>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_position",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the window tabpage
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// Tabpage that contains the window
+            /// </para>
+            /// </returns>
+            public Task<NvimTabpage> GetTabpage() =>
+                _api.SendAndReceive<NvimTabpage>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_tabpage",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the window number
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// Window number
+            /// </para>
+            /// </returns>
+            public Task<long> GetNumber() =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_get_number",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Checks if a window is valid
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// true if the window is valid, false otherwise
+            /// </para>
+            /// </returns>
+            public Task<bool> IsValid() =>
+                _api.SendAndReceive<bool>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_is_valid",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Closes the window and hide the buffer it contains (like |:hide| with a |window-ID|).
+            /// </para>
+            /// </summary>
+            public Task Hide() =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_hide",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Closes the window (like |:close| with a |window-ID|).
+            /// </para>
+            /// </summary>
+            /// <param name="force">
+            /// <para>
+            /// Behave like
+            /// </para>
+            /// </param>
+            public Task Close(bool @force) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_close",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @force),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Set highlight namespace for a window. This will use highlights defined with |nvim_set_hl()| for this namespace, but fall back to global highlights (ns=0) when missing.
+            /// </para>
+            /// </summary>
+            /// <param name="nsId">
+            /// <para>
+            /// the namespace to use
+            /// </para>
+            /// </param>
+            public Task SetHlNs(long @nsId) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_set_hl_ns",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @nsId),
+                    }
+                );
+
+            public Task<IDictionary> TextHeight(IDictionary @opts) =>
+                _api.SendAndReceive<IDictionary>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_win_text_height",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @opts),
+                    }
+                );
+        }
+
+        public class NvimTabpage
+        {
+            private readonly NvimAPI _api;
+            private readonly MessagePackExtendedTypeObject _msgPackExtObj;
+
+            internal NvimTabpage(NvimAPI api, MessagePackExtendedTypeObject msgPackExtObj)
+            {
+                _api = api;
+                _msgPackExtObj = msgPackExtObj;
+            }
+
+            /// <summary>
+            /// <para>
+            /// Gets the windows in a tabpage
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// List of windows in
+            /// </para>
+            /// </returns>
+            public Task<object[]> ListWins() =>
+                _api.SendAndReceive<object[]>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_tabpage_list_wins",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets a tab-scoped (t:) variable
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Variable name
+            /// </para>
+            /// </param>
+            /// <returns>
+            /// <para>
+            /// Variable value
+            /// </para>
+            /// </returns>
+            public Task<object> GetVar(string @name) =>
+                _api.SendAndReceive<object>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_tabpage_get_var",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets a tab-scoped (t:) variable
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Variable name
+            /// </para>
+            /// </param>
+            /// <param name="value">
+            /// <para>
+            /// Variable value
+            /// </para>
+            /// </param>
+            public Task SetVar(string @name, object @value) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_tabpage_set_var",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name, @value),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Removes a tab-scoped (t:) variable
+            /// </para>
+            /// </summary>
+            /// <param name="name">
+            /// <para>
+            /// Variable name
+            /// </para>
+            /// </param>
+            public Task DelVar(string @name) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_tabpage_del_var",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @name),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the current window in a tabpage
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// |window-ID|
+            /// </para>
+            /// </returns>
+            public Task<NvimWindow> GetWin() =>
+                _api.SendAndReceive<NvimWindow>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_tabpage_get_win",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Sets the current window in a tabpage
+            /// </para>
+            /// </summary>
+            /// <param name="win">
+            /// <para>
+            /// |window-ID|, must already belong to {tabpage}
+            /// </para>
+            /// </param>
+            public Task SetWin(NvimWindow @win) =>
+                _api.SendAndReceive(
+                    new NvimRequest
+                    {
+                        Method = "nvim_tabpage_set_win",
+                        Arguments = GetRequestArguments(_msgPackExtObj, @win),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Gets the tabpage number
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// Tabpage number
+            /// </para>
+            /// </returns>
+            public Task<long> GetNumber() =>
+                _api.SendAndReceive<long>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_tabpage_get_number",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+
+            /// <summary>
+            /// <para>
+            /// Checks if a tabpage is valid
+            /// </para>
+            /// </summary>
+            /// <returns>
+            /// <para>
+            /// true if the tabpage is valid, false otherwise
+            /// </para>
+            /// </returns>
+            public Task<bool> IsValid() =>
+                _api.SendAndReceive<bool>(
+                    new NvimRequest
+                    {
+                        Method = "nvim_tabpage_is_valid",
+                        Arguments = GetRequestArguments(_msgPackExtObj),
+                    }
+                );
+        }
+
+        public class ModeInfoSetEventArgs : EventArgs
+        {
+            public bool Enabled { get; set; }
+            public object[] CursorStyles { get; set; }
+        }
+
+        public class ModeChangeEventArgs : EventArgs
+        {
+            public string Mode { get; set; }
+            public long ModeIdx { get; set; }
+        }
+
+        public class ConnectEventArgs : EventArgs
+        {
+            public string ServerAddr { get; set; }
+        }
+
+        public class RestartEventArgs : EventArgs
+        {
+            public string ListenAddr { get; set; }
+        }
+
+        public class SetTitleEventArgs : EventArgs
+        {
+            public string Title { get; set; }
+        }
+
+        public class SetIconEventArgs : EventArgs
+        {
+            public string Icon { get; set; }
+        }
+
+        public class ScreenshotEventArgs : EventArgs
+        {
+            public string Path { get; set; }
+        }
+
+        public class OptionSetEventArgs : EventArgs
+        {
+            public string Name { get; set; }
+            public object Value { get; set; }
+        }
+
+        public class ChdirEventArgs : EventArgs
+        {
+            public string Path { get; set; }
+        }
+
+        public class UiSendEventArgs : EventArgs
+        {
+            public string Content { get; set; }
+        }
+
+        public class UpdateFgEventArgs : EventArgs
+        {
+            public long Fg { get; set; }
+        }
+
+        public class UpdateBgEventArgs : EventArgs
+        {
+            public long Bg { get; set; }
+        }
+
+        public class UpdateSpEventArgs : EventArgs
+        {
+            public long Sp { get; set; }
+        }
+
+        public class ResizeEventArgs : EventArgs
+        {
+            public long Width { get; set; }
+            public long Height { get; set; }
+        }
+
+        public class CursorGotoEventArgs : EventArgs
+        {
+            public long Row { get; set; }
+            public long Col { get; set; }
+        }
+
+        public class HighlightSetEventArgs : EventArgs
+        {
+            public IDictionary Attrs { get; set; }
+        }
+
+        public class PutEventArgs : EventArgs
+        {
+            public string Str { get; set; }
+        }
+
+        public class SetScrollRegionEventArgs : EventArgs
+        {
+            public long Top { get; set; }
+            public long Bot { get; set; }
+            public long Left { get; set; }
+            public long Right { get; set; }
+        }
+
+        public class ScrollEventArgs : EventArgs
+        {
+            public long Count { get; set; }
+        }
+
+        public class DefaultColorsSetEventArgs : EventArgs
+        {
+            public long RgbFg { get; set; }
+            public long RgbBg { get; set; }
+            public long RgbSp { get; set; }
+            public long CtermFg { get; set; }
+            public long CtermBg { get; set; }
+        }
+
+        public class HlAttrDefineEventArgs : EventArgs
+        {
+            public long Id { get; set; }
+            public IDictionary RgbAttrs { get; set; }
+            public IDictionary CtermAttrs { get; set; }
+            public object[] Info { get; set; }
+        }
+
+        public class HlGroupSetEventArgs : EventArgs
+        {
+            public string Name { get; set; }
+            public long Id { get; set; }
+        }
+
+        public class GridResizeEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public long Width { get; set; }
+            public long Height { get; set; }
+        }
+
+        public class GridClearEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+        }
+
+        public class GridCursorGotoEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public long Row { get; set; }
+            public long Col { get; set; }
+        }
+
+        public class GridLineEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public long Row { get; set; }
+            public long ColStart { get; set; }
+            public object[] Data { get; set; }
+            public bool Wrap { get; set; }
+        }
+
+        public class GridScrollEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public long Top { get; set; }
+            public long Bot { get; set; }
+            public long Left { get; set; }
+            public long Right { get; set; }
+            public long Rows { get; set; }
+            public long Cols { get; set; }
+        }
+
+        public class GridDestroyEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+        }
+
+        public class WinPosEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public NvimWindow Win { get; set; }
+            public long Startrow { get; set; }
+            public long Startcol { get; set; }
+            public long Width { get; set; }
+            public long Height { get; set; }
+        }
+
+        public class WinFloatPosEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public NvimWindow Win { get; set; }
+            public string Anchor { get; set; }
+            public long AnchorGrid { get; set; }
+            public double AnchorRow { get; set; }
+            public double AnchorCol { get; set; }
+            public bool MouseEnabled { get; set; }
+            public long Zindex { get; set; }
+            public long Compindex { get; set; }
+            public long ScreenRow { get; set; }
+            public long ScreenCol { get; set; }
+        }
+
+        public class WinExternalPosEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public NvimWindow Win { get; set; }
+        }
+
+        public class WinHideEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+        }
+
+        public class WinCloseEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+        }
+
+        public class MsgSetPosEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public long Row { get; set; }
+            public bool Scrolled { get; set; }
+            public string SepChar { get; set; }
+            public long Zindex { get; set; }
+            public long Compindex { get; set; }
+        }
+
+        public class WinViewportEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public NvimWindow Win { get; set; }
+            public long Topline { get; set; }
+            public long Botline { get; set; }
+            public long Curline { get; set; }
+            public long Curcol { get; set; }
+            public long LineCount { get; set; }
+            public long ScrollDelta { get; set; }
+        }
+
+        public class WinViewportMarginsEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public NvimWindow Win { get; set; }
+            public long Top { get; set; }
+            public long Bottom { get; set; }
+            public long Left { get; set; }
+            public long Right { get; set; }
+        }
+
+        public class WinExtmarkEventArgs : EventArgs
+        {
+            public long Grid { get; set; }
+            public NvimWindow Win { get; set; }
+            public long NsId { get; set; }
+            public long MarkId { get; set; }
+            public long Row { get; set; }
+            public long Col { get; set; }
+        }
+
+        public class PopupmenuShowEventArgs : EventArgs
+        {
+            public object[] Items { get; set; }
+            public long Selected { get; set; }
+            public long Row { get; set; }
+            public long Col { get; set; }
+            public long Grid { get; set; }
+        }
+
+        public class PopupmenuSelectEventArgs : EventArgs
+        {
+            public long Selected { get; set; }
+        }
+
+        public class TablineUpdateEventArgs : EventArgs
+        {
+            public NvimTabpage Current { get; set; }
+            public object[] Tabs { get; set; }
+            public NvimBuffer CurrentBuffer { get; set; }
+            public object[] Buffers { get; set; }
+        }
+
+        public class CmdlineShowEventArgs : EventArgs
+        {
+            public object[] Content { get; set; }
+            public long Pos { get; set; }
+            public string Firstc { get; set; }
+            public string Prompt { get; set; }
+            public long Indent { get; set; }
+            public long Level { get; set; }
+            public long HlId { get; set; }
+        }
+
+        public class CmdlinePosEventArgs : EventArgs
+        {
+            public long Pos { get; set; }
+            public long Level { get; set; }
+        }
+
+        public class CmdlineSpecialCharEventArgs : EventArgs
+        {
+            public string C { get; set; }
+            public bool Shift { get; set; }
+            public long Level { get; set; }
+        }
+
+        public class CmdlineHideEventArgs : EventArgs
+        {
+            public long Level { get; set; }
+            public bool Abort { get; set; }
+        }
+
+        public class CmdlineBlockShowEventArgs : EventArgs
+        {
+            public object[] Lines { get; set; }
+        }
+
+        public class CmdlineBlockAppendEventArgs : EventArgs
+        {
+            public object[] Lines { get; set; }
+        }
+
+        public class WildmenuShowEventArgs : EventArgs
+        {
+            public object[] Items { get; set; }
+        }
+
+        public class WildmenuSelectEventArgs : EventArgs
+        {
+            public long Selected { get; set; }
+        }
+
+        public class MsgShowEventArgs : EventArgs
+        {
+            public string Kind { get; set; }
+            public object[] Content { get; set; }
+            public bool ReplaceLast { get; set; }
+            public bool History { get; set; }
+            public bool Append { get; set; }
+            public object Id { get; set; }
+            public string Trigger { get; set; }
+        }
+
+        public class MsgShowcmdEventArgs : EventArgs
+        {
+            public object[] Content { get; set; }
+        }
+
+        public class MsgShowmodeEventArgs : EventArgs
+        {
+            public object[] Content { get; set; }
+        }
+
+        public class MsgRulerEventArgs : EventArgs
+        {
+            public object[] Content { get; set; }
+        }
+
+        public class MsgHistoryShowEventArgs : EventArgs
+        {
+            public object[] Entries { get; set; }
+            public bool PrevCmd { get; set; }
+        }
+
+        public class ErrorExitEventArgs : EventArgs
+        {
+            public long Status { get; set; }
+        }
+
+        private void CallUIEventHandler(string eventName, object[] args)
+        {
+            switch (eventName)
+            {
+                case "mode_info_set":
+                    ModeInfoSetEvent?.Invoke(
+                        this,
+                        new ModeInfoSetEventArgs
+                        {
+                            Enabled = (bool)args[0],
+                            CursorStyles = (object[])args[1],
+                        }
+                    );
+                    break;
+
+                case "update_menu":
+                    UpdateMenuEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "busy_start":
+                    BusyStartEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "busy_stop":
+                    BusyStopEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "mouse_on":
+                    MouseOnEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "mouse_off":
+                    MouseOffEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "mode_change":
+                    ModeChangeEvent?.Invoke(
+                        this,
+                        new ModeChangeEventArgs { Mode = (string)args[0], ModeIdx = (long)args[1] }
+                    );
+                    break;
+
+                case "bell":
+                    BellEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "visual_bell":
+                    VisualBellEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "flush":
+                    FlushEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "connect":
+                    ConnectEvent?.Invoke(
+                        this,
+                        new ConnectEventArgs { ServerAddr = (string)args[0] }
+                    );
+                    break;
+
+                case "restart":
+                    RestartEvent?.Invoke(
+                        this,
+                        new RestartEventArgs { ListenAddr = (string)args[0] }
+                    );
+                    break;
+
+                case "suspend":
+                    SuspendEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "set_title":
+                    SetTitleEvent?.Invoke(this, new SetTitleEventArgs { Title = (string)args[0] });
+                    break;
+
+                case "set_icon":
+                    SetIconEvent?.Invoke(this, new SetIconEventArgs { Icon = (string)args[0] });
+                    break;
+
+                case "screenshot":
+                    ScreenshotEvent?.Invoke(
+                        this,
+                        new ScreenshotEventArgs { Path = (string)args[0] }
+                    );
+                    break;
+
+                case "option_set":
+                    OptionSetEvent?.Invoke(
+                        this,
+                        new OptionSetEventArgs { Name = (string)args[0], Value = (object)args[1] }
+                    );
+                    break;
+
+                case "chdir":
+                    ChdirEvent?.Invoke(this, new ChdirEventArgs { Path = (string)args[0] });
+                    break;
+
+                case "ui_send":
+                    UiSendEvent?.Invoke(this, new UiSendEventArgs { Content = (string)args[0] });
+                    break;
+
+                case "update_fg":
+                    UpdateFgEvent?.Invoke(this, new UpdateFgEventArgs { Fg = (long)args[0] });
+                    break;
+
+                case "update_bg":
+                    UpdateBgEvent?.Invoke(this, new UpdateBgEventArgs { Bg = (long)args[0] });
+                    break;
+
+                case "update_sp":
+                    UpdateSpEvent?.Invoke(this, new UpdateSpEventArgs { Sp = (long)args[0] });
+                    break;
+
+                case "resize":
+                    ResizeEvent?.Invoke(
+                        this,
+                        new ResizeEventArgs { Width = (long)args[0], Height = (long)args[1] }
+                    );
+                    break;
+
+                case "clear":
+                    ClearEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "eol_clear":
+                    EolClearEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "cursor_goto":
+                    CursorGotoEvent?.Invoke(
+                        this,
+                        new CursorGotoEventArgs { Row = (long)args[0], Col = (long)args[1] }
+                    );
+                    break;
+
+                case "highlight_set":
+                    HighlightSetEvent?.Invoke(
+                        this,
+                        new HighlightSetEventArgs { Attrs = (IDictionary)args[0] }
+                    );
+                    break;
+
+                case "put":
+                    PutEvent?.Invoke(this, new PutEventArgs { Str = (string)args[0] });
+                    break;
+
+                case "set_scroll_region":
+                    SetScrollRegionEvent?.Invoke(
+                        this,
+                        new SetScrollRegionEventArgs
+                        {
+                            Top = (long)args[0],
+                            Bot = (long)args[1],
+                            Left = (long)args[2],
+                            Right = (long)args[3],
+                        }
+                    );
+                    break;
+
+                case "scroll":
+                    ScrollEvent?.Invoke(this, new ScrollEventArgs { Count = (long)args[0] });
+                    break;
+
+                case "default_colors_set":
+                    DefaultColorsSetEvent?.Invoke(
+                        this,
+                        new DefaultColorsSetEventArgs
+                        {
+                            RgbFg = (long)args[0],
+                            RgbBg = (long)args[1],
+                            RgbSp = (long)args[2],
+                            CtermFg = (long)args[3],
+                            CtermBg = (long)args[4],
+                        }
+                    );
+                    break;
+
+                case "hl_attr_define":
+                    HlAttrDefineEvent?.Invoke(
+                        this,
+                        new HlAttrDefineEventArgs
+                        {
+                            Id = (long)args[0],
+                            RgbAttrs = (IDictionary)args[1],
+                            CtermAttrs = (IDictionary)args[2],
+                            Info = (object[])args[3],
+                        }
+                    );
+                    break;
+
+                case "hl_group_set":
+                    HlGroupSetEvent?.Invoke(
+                        this,
+                        new HlGroupSetEventArgs { Name = (string)args[0], Id = (long)args[1] }
+                    );
+                    break;
+
+                case "grid_resize":
+                    GridResizeEvent?.Invoke(
+                        this,
+                        new GridResizeEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Width = (long)args[1],
+                            Height = (long)args[2],
+                        }
+                    );
+                    break;
+
+                case "grid_clear":
+                    GridClearEvent?.Invoke(this, new GridClearEventArgs { Grid = (long)args[0] });
+                    break;
+
+                case "grid_cursor_goto":
+                    GridCursorGotoEvent?.Invoke(
+                        this,
+                        new GridCursorGotoEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Row = (long)args[1],
+                            Col = (long)args[2],
+                        }
+                    );
+                    break;
+
+                case "grid_line":
+                    GridLineEvent?.Invoke(
+                        this,
+                        new GridLineEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Row = (long)args[1],
+                            ColStart = (long)args[2],
+                            Data = (object[])args[3],
+                            Wrap = (bool)args[4],
+                        }
+                    );
+                    break;
+
+                case "grid_scroll":
+                    GridScrollEvent?.Invoke(
+                        this,
+                        new GridScrollEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Top = (long)args[1],
+                            Bot = (long)args[2],
+                            Left = (long)args[3],
+                            Right = (long)args[4],
+                            Rows = (long)args[5],
+                            Cols = (long)args[6],
+                        }
+                    );
+                    break;
+
+                case "grid_destroy":
+                    GridDestroyEvent?.Invoke(
+                        this,
+                        new GridDestroyEventArgs { Grid = (long)args[0] }
+                    );
+                    break;
+
+                case "win_pos":
+                    WinPosEvent?.Invoke(
+                        this,
+                        new WinPosEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Win = (NvimWindow)args[1],
+                            Startrow = (long)args[2],
+                            Startcol = (long)args[3],
+                            Width = (long)args[4],
+                            Height = (long)args[5],
+                        }
+                    );
+                    break;
+
+                case "win_float_pos":
+                    WinFloatPosEvent?.Invoke(
+                        this,
+                        new WinFloatPosEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Win = (NvimWindow)args[1],
+                            Anchor = (string)args[2],
+                            AnchorGrid = (long)args[3],
+                            AnchorRow = (double)args[4],
+                            AnchorCol = (double)args[5],
+                            MouseEnabled = (bool)args[6],
+                            Zindex = (long)args[7],
+                            Compindex = (long)args[8],
+                            ScreenRow = (long)args[9],
+                            ScreenCol = (long)args[10],
+                        }
+                    );
+                    break;
+
+                case "win_external_pos":
+                    WinExternalPosEvent?.Invoke(
+                        this,
+                        new WinExternalPosEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Win = (NvimWindow)args[1],
+                        }
+                    );
+                    break;
+
+                case "win_hide":
+                    WinHideEvent?.Invoke(this, new WinHideEventArgs { Grid = (long)args[0] });
+                    break;
+
+                case "win_close":
+                    WinCloseEvent?.Invoke(this, new WinCloseEventArgs { Grid = (long)args[0] });
+                    break;
+
+                case "msg_set_pos":
+                    MsgSetPosEvent?.Invoke(
+                        this,
+                        new MsgSetPosEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Row = (long)args[1],
+                            Scrolled = (bool)args[2],
+                            SepChar = (string)args[3],
+                            Zindex = (long)args[4],
+                            Compindex = (long)args[5],
+                        }
+                    );
+                    break;
+
+                case "win_viewport":
+                    WinViewportEvent?.Invoke(
+                        this,
+                        new WinViewportEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Win = (NvimWindow)args[1],
+                            Topline = (long)args[2],
+                            Botline = (long)args[3],
+                            Curline = (long)args[4],
+                            Curcol = (long)args[5],
+                            LineCount = (long)args[6],
+                            ScrollDelta = (long)args[7],
+                        }
+                    );
+                    break;
+
+                case "win_viewport_margins":
+                    WinViewportMarginsEvent?.Invoke(
+                        this,
+                        new WinViewportMarginsEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Win = (NvimWindow)args[1],
+                            Top = (long)args[2],
+                            Bottom = (long)args[3],
+                            Left = (long)args[4],
+                            Right = (long)args[5],
+                        }
+                    );
+                    break;
+
+                case "win_extmark":
+                    WinExtmarkEvent?.Invoke(
+                        this,
+                        new WinExtmarkEventArgs
+                        {
+                            Grid = (long)args[0],
+                            Win = (NvimWindow)args[1],
+                            NsId = (long)args[2],
+                            MarkId = (long)args[3],
+                            Row = (long)args[4],
+                            Col = (long)args[5],
+                        }
+                    );
+                    break;
+
+                case "popupmenu_show":
+                    PopupmenuShowEvent?.Invoke(
+                        this,
+                        new PopupmenuShowEventArgs
+                        {
+                            Items = (object[])args[0],
+                            Selected = (long)args[1],
+                            Row = (long)args[2],
+                            Col = (long)args[3],
+                            Grid = (long)args[4],
+                        }
+                    );
+                    break;
+
+                case "popupmenu_hide":
+                    PopupmenuHideEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "popupmenu_select":
+                    PopupmenuSelectEvent?.Invoke(
+                        this,
+                        new PopupmenuSelectEventArgs { Selected = (long)args[0] }
+                    );
+                    break;
+
+                case "tabline_update":
+                    TablineUpdateEvent?.Invoke(
+                        this,
+                        new TablineUpdateEventArgs
+                        {
+                            Current = (NvimTabpage)args[0],
+                            Tabs = (object[])args[1],
+                            CurrentBuffer = (NvimBuffer)args[2],
+                            Buffers = (object[])args[3],
+                        }
+                    );
+                    break;
+
+                case "cmdline_show":
+                    CmdlineShowEvent?.Invoke(
+                        this,
+                        new CmdlineShowEventArgs
+                        {
+                            Content = (object[])args[0],
+                            Pos = (long)args[1],
+                            Firstc = (string)args[2],
+                            Prompt = (string)args[3],
+                            Indent = (long)args[4],
+                            Level = (long)args[5],
+                            HlId = (long)args[6],
+                        }
+                    );
+                    break;
+
+                case "cmdline_pos":
+                    CmdlinePosEvent?.Invoke(
+                        this,
+                        new CmdlinePosEventArgs { Pos = (long)args[0], Level = (long)args[1] }
+                    );
+                    break;
+
+                case "cmdline_special_char":
+                    CmdlineSpecialCharEvent?.Invoke(
+                        this,
+                        new CmdlineSpecialCharEventArgs
+                        {
+                            C = (string)args[0],
+                            Shift = (bool)args[1],
+                            Level = (long)args[2],
+                        }
+                    );
+                    break;
+
+                case "cmdline_hide":
+                    CmdlineHideEvent?.Invoke(
+                        this,
+                        new CmdlineHideEventArgs { Level = (long)args[0], Abort = (bool)args[1] }
+                    );
+                    break;
+
+                case "cmdline_block_show":
+                    CmdlineBlockShowEvent?.Invoke(
+                        this,
+                        new CmdlineBlockShowEventArgs { Lines = (object[])args[0] }
+                    );
+                    break;
+
+                case "cmdline_block_append":
+                    CmdlineBlockAppendEvent?.Invoke(
+                        this,
+                        new CmdlineBlockAppendEventArgs { Lines = (object[])args[0] }
+                    );
+                    break;
+
+                case "cmdline_block_hide":
+                    CmdlineBlockHideEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "wildmenu_show":
+                    WildmenuShowEvent?.Invoke(
+                        this,
+                        new WildmenuShowEventArgs { Items = (object[])args[0] }
+                    );
+                    break;
+
+                case "wildmenu_select":
+                    WildmenuSelectEvent?.Invoke(
+                        this,
+                        new WildmenuSelectEventArgs { Selected = (long)args[0] }
+                    );
+                    break;
+
+                case "wildmenu_hide":
+                    WildmenuHideEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "msg_show":
+                    MsgShowEvent?.Invoke(
+                        this,
+                        new MsgShowEventArgs
+                        {
+                            Kind = (string)args[0],
+                            Content = (object[])args[1],
+                            ReplaceLast = (bool)args[2],
+                            History = (bool)args[3],
+                            Append = (bool)args[4],
+                            Id = (object)args[5],
+                            Trigger = (string)args[6],
+                        }
+                    );
+                    break;
+
+                case "msg_clear":
+                    MsgClearEvent?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case "msg_showcmd":
+                    MsgShowcmdEvent?.Invoke(
+                        this,
+                        new MsgShowcmdEventArgs { Content = (object[])args[0] }
+                    );
+                    break;
+
+                case "msg_showmode":
+                    MsgShowmodeEvent?.Invoke(
+                        this,
+                        new MsgShowmodeEventArgs { Content = (object[])args[0] }
+                    );
+                    break;
+
+                case "msg_ruler":
+                    MsgRulerEvent?.Invoke(
+                        this,
+                        new MsgRulerEventArgs { Content = (object[])args[0] }
+                    );
+                    break;
+
+                case "msg_history_show":
+                    MsgHistoryShowEvent?.Invoke(
+                        this,
+                        new MsgHistoryShowEventArgs
+                        {
+                            Entries = (object[])args[0],
+                            PrevCmd = (bool)args[1],
+                        }
+                    );
+                    break;
+
+                case "error_exit":
+                    ErrorExitEvent?.Invoke(this, new ErrorExitEventArgs { Status = (long)args[0] });
+                    break;
+            }
+        }
+
+        private object GetExtensionType(MessagePackExtendedTypeObject msgPackExtObj)
+        {
+            switch (msgPackExtObj.TypeCode)
+            {
+                case 0:
+                    return new NvimBuffer(this, msgPackExtObj);
+                case 1:
+                    return new NvimWindow(this, msgPackExtObj);
+                case 2:
+                    return new NvimTabpage(this, msgPackExtObj);
+                default:
+                    throw new SerializationException(
+                        $"Unknown extension type id {msgPackExtObj.TypeCode}"
+                    );
+            }
+        }
     }
-    
-    /// <summary>
-    /// <para>
-    /// Gets the buffer line count
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Line count, or 0 for unloaded buffer. |api-buffer| 
-    /// </para>
-    /// </returns>
-    public Task<long> LineCount() =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_buf_line_count",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Activates buffer-update events on a channel, or as Lua callbacks.
-    /// </para>
-    /// </summary>
-    /// <param name="sendBuffer">
-    /// <para>
-    /// True if the initial notification should contain the whole buffer: first notification will be 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters.
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// False if attach failed (invalid parameter, or buffer isn&apos;t loaded); otherwise True. TODO: LUA_API_NO_EVAL 
-    /// </para>
-    /// </returns>
-    public Task<bool> Attach(bool @sendBuffer, IDictionary @opts) =>
-      _api.SendAndReceive<bool>(new NvimRequest
-      {
-        Method = "nvim_buf_attach",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @sendBuffer, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Deactivates buffer-update events on the channel.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// False if detach failed (because the buffer isn&apos;t loaded); otherwise True. 
-    /// </para>
-    /// </returns>
-    public Task<bool> Detach() =>
-      _api.SendAndReceive<bool>(new NvimRequest
-      {
-        Method = "nvim_buf_detach",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a line-range from the buffer.
-    /// </para>
-    /// </summary>
-    /// <param name="start">
-    /// <para>
-    /// First line index 
-    /// </para>
-    /// </param>
-    /// <param name="end">
-    /// <para>
-    /// Last line index (exclusive) 
-    /// </para>
-    /// </param>
-    /// <param name="strictIndexing">
-    /// <para>
-    /// Whether out-of-bounds should be an error. 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Array of lines, or empty array for unloaded buffer. 
-    /// </para>
-    /// </returns>
-    public Task<string[]> GetLines(long @start, long @end, bool @strictIndexing) =>
-      _api.SendAndReceive<string[]>(new NvimRequest
-      {
-        Method = "nvim_buf_get_lines",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @start, @end, @strictIndexing)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets (replaces) a line-range in the buffer.
-    /// </para>
-    /// </summary>
-    /// <param name="start">
-    /// <para>
-    /// First line index 
-    /// </para>
-    /// </param>
-    /// <param name="end">
-    /// <para>
-    /// Last line index (exclusive) 
-    /// </para>
-    /// </param>
-    /// <param name="strictIndexing">
-    /// <para>
-    /// Whether out-of-bounds should be an error. 
-    /// </para>
-    /// </param>
-    /// <param name="replacement">
-    /// <para>
-    /// Array of lines to use as replacement 
-    /// </para>
-    /// </param>
-    public Task SetLines(long @start, long @end, bool @strictIndexing, string[] @replacement) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_set_lines",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @start, @end, @strictIndexing, @replacement)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets (replaces) a range in the buffer
-    /// </para>
-    /// </summary>
-    /// <param name="startRow">
-    /// <para>
-    /// First line index 
-    /// </para>
-    /// </param>
-    /// <param name="endRow">
-    /// <para>
-    /// Last line index 
-    /// </para>
-    /// </param>
-    /// <param name="replacement">
-    /// <para>
-    /// Array of lines to use as replacement 
-    /// </para>
-    /// </param>
-    public Task SetText(long @startRow, long @startCol, long @endRow, long @endCol, string[] @replacement) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_set_text",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @startRow, @startCol, @endRow, @endCol, @replacement)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Returns the byte offset of a line (0-indexed). |api-indexing|
-    /// </para>
-    /// </summary>
-    /// <param name="index">
-    /// <para>
-    /// Line index 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Integer byte offset, or -1 for unloaded buffer. 
-    /// </para>
-    /// </returns>
-    public Task<long> GetOffset(long @index) =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_buf_get_offset",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @index)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a buffer-scoped (b:) variable.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </returns>
-    public Task<object> GetVar(string @name) =>
-      _api.SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_buf_get_var",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a changed tick of a buffer
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// <c>$b:changedtick</c>
-    /// </para>
-    /// </returns>
-    public Task<long> GetChangedtick() =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_buf_get_changedtick",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a list of buffer-local |mapping| definitions.
-    /// </para>
-    /// </summary>
-    /// <param name="mode">
-    /// <para>
-    /// Mode short-name (&quot;n&quot;, &quot;i&quot;, &quot;v&quot;, ...) 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Array of maparg()-like dictionaries describing mappings. The &quot;buffer&quot; key holds the associated buffer handle. 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary[]> GetKeymap(string @mode) =>
-      _api.SendAndReceive<IDictionary[]>(new NvimRequest
-      {
-        Method = "nvim_buf_get_keymap",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @mode)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets a buffer-local |mapping| for the given mode.
-    /// </para>
-    /// </summary>
-    public Task SetKeymap(string @mode, string @lhs, string @rhs, IDictionary @opts) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_set_keymap",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @mode, @lhs, @rhs, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Unmaps a buffer-local |mapping| for the given mode.
-    /// </para>
-    /// </summary>
-    public Task DelKeymap(string @mode, string @lhs) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_del_keymap",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @mode, @lhs)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a map of buffer-local |user-commands|.
-    /// </para>
-    /// </summary>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters. Currently not used. 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Map of maps describing commands. 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetCommands(IDictionary @opts) =>
-      _api.SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_buf_get_commands",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets a buffer-scoped (b:) variable
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <param name="value">
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </param>
-    public Task SetVar(string @name, object @value) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_set_var",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name, @value)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Removes a buffer-scoped (b:) variable
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    public Task DelVar(string @name) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_del_var",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a buffer option value
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Option name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Option value 
-    /// </para>
-    /// </returns>
-    public Task<object> GetOption(string @name) =>
-      _api.SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_buf_get_option",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets a buffer option value. Passing &apos;nil&apos; as value deletes the option (only works if there&apos;s a global fallback)
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Option name 
-    /// </para>
-    /// </param>
-    /// <param name="value">
-    /// <para>
-    /// Option value 
-    /// </para>
-    /// </param>
-    public Task SetOption(string @name, object @value) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_set_option",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name, @value)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the full file name for the buffer
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Buffer name 
-    /// </para>
-    /// </returns>
-    public Task<string> GetName() =>
-      _api.SendAndReceive<string>(new NvimRequest
-      {
-        Method = "nvim_buf_get_name",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the full file name for a buffer
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Buffer name 
-    /// </para>
-    /// </param>
-    public Task SetName(string @name) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_set_name",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Checks if a buffer is valid and loaded. See |api-buffer| for more info about unloaded buffers.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// true if the buffer is valid and loaded, false otherwise. 
-    /// </para>
-    /// </returns>
-    public Task<bool> IsLoaded() =>
-      _api.SendAndReceive<bool>(new NvimRequest
-      {
-        Method = "nvim_buf_is_loaded",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Deletes the buffer. See |:bwipeout|
-    /// </para>
-    /// </summary>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters. Keys:
-    /// </para>
-    /// </param>
-    public Task Delete(IDictionary @opts) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_delete",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Checks if a buffer is valid.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// true if the buffer is valid, false otherwise. 
-    /// </para>
-    /// </returns>
-    /// <remarks>
-    /// Even if a buffer is valid it may have been unloaded. See |api-buffer| for more info about unloaded buffers.
-    /// </remarks>
-    public Task<bool> IsValid() =>
-      _api.SendAndReceive<bool>(new NvimRequest
-      {
-        Method = "nvim_buf_is_valid",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Return a tuple (row,col) representing the position of the named mark.
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Mark name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// (row, col) tuple 
-    /// </para>
-    /// </returns>
-    public Task<long[]> GetMark(string @name) =>
-      _api.SendAndReceive<long[]>(new NvimRequest
-      {
-        Method = "nvim_buf_get_mark",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Returns position for a given extmark id
-    /// </para>
-    /// </summary>
-    /// <param name="nsId">
-    /// <para>
-    /// Namespace id from |nvim_create_namespace()| 
-    /// </para>
-    /// </param>
-    /// <param name="id">
-    /// <para>
-    /// Extmark id 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters. Keys:
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// (row, col) tuple or empty list () if extmark id was absent 
-    /// </para>
-    /// </returns>
-    public Task<long[]> GetExtmarkById(long @nsId, long @id, IDictionary @opts) =>
-      _api.SendAndReceive<long[]>(new NvimRequest
-      {
-        Method = "nvim_buf_get_extmark_by_id",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @nsId, @id, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets extmarks in &quot;traversal order&quot; from a |charwise| region defined by buffer positions (inclusive, 0-indexed |api-indexing|).
-    /// </para>
-    /// </summary>
-    /// <param name="nsId">
-    /// <para>
-    /// Namespace id from |nvim_create_namespace()| 
-    /// </para>
-    /// </param>
-    /// <param name="start">
-    /// <para>
-    /// Start of range, given as (row, col) or valid extmark id (whose position defines the bound) 
-    /// </para>
-    /// </param>
-    /// <param name="end">
-    /// <para>
-    /// End of range, given as (row, col) or valid extmark id (whose position defines the bound) 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters. Keys:
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// List of [extmark_id, row, col] tuples in &quot;traversal order&quot;. 
-    /// </para>
-    /// </returns>
-    public Task<object[]> GetExtmarks(long @nsId, object @start, object @end, IDictionary @opts) =>
-      _api.SendAndReceive<object[]>(new NvimRequest
-      {
-        Method = "nvim_buf_get_extmarks",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @nsId, @start, @end, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Creates or updates an extmark.
-    /// </para>
-    /// </summary>
-    /// <param name="nsId">
-    /// <para>
-    /// Namespace id from |nvim_create_namespace()| 
-    /// </para>
-    /// </param>
-    /// <param name="line">
-    /// <para>
-    /// Line where to place the mark, 0-based 
-    /// </para>
-    /// </param>
-    /// <param name="col">
-    /// <para>
-    /// Column where to place the mark, 0-based 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters.
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Id of the created/updated extmark 
-    /// </para>
-    /// </returns>
-    public Task<long> SetExtmark(long @nsId, long @line, long @col, IDictionary @opts) =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_buf_set_extmark",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @nsId, @line, @col, @opts)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Removes an extmark.
-    /// </para>
-    /// </summary>
-    /// <param name="nsId">
-    /// <para>
-    /// Namespace id from |nvim_create_namespace()| 
-    /// </para>
-    /// </param>
-    /// <param name="id">
-    /// <para>
-    /// Extmark id 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// true if the extmark was found, else false 
-    /// </para>
-    /// </returns>
-    public Task<bool> DelExtmark(long @nsId, long @id) =>
-      _api.SendAndReceive<bool>(new NvimRequest
-      {
-        Method = "nvim_buf_del_extmark",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @nsId, @id)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Adds a highlight to buffer.
-    /// </para>
-    /// </summary>
-    /// <param name="nsId">
-    /// <para>
-    /// namespace to use or -1 for ungrouped highlight 
-    /// </para>
-    /// </param>
-    /// <param name="hlGroup">
-    /// <para>
-    /// Name of the highlight group to use 
-    /// </para>
-    /// </param>
-    /// <param name="line">
-    /// <para>
-    /// Line to highlight (zero-indexed) 
-    /// </para>
-    /// </param>
-    /// <param name="colStart">
-    /// <para>
-    /// Start of (byte-indexed) column range to highlight 
-    /// </para>
-    /// </param>
-    /// <param name="colEnd">
-    /// <para>
-    /// End of (byte-indexed) column range to highlight, or -1 to highlight to end of line 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// The ns_id that was used 
-    /// </para>
-    /// </returns>
-    public Task<long> AddHighlight(long @nsId, string @hlGroup, long @line, long @colStart, long @colEnd) =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_buf_add_highlight",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @nsId, @hlGroup, @line, @colStart, @colEnd)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Clears namespaced objects (highlights, extmarks, virtual text) from a region.
-    /// </para>
-    /// </summary>
-    /// <param name="nsId">
-    /// <para>
-    /// Namespace to clear, or -1 to clear all namespaces. 
-    /// </para>
-    /// </param>
-    /// <param name="lineStart">
-    /// <para>
-    /// Start of range of lines to clear 
-    /// </para>
-    /// </param>
-    /// <param name="lineEnd">
-    /// <para>
-    /// End of range of lines to clear (exclusive) or -1 to clear to end of buffer. 
-    /// </para>
-    /// </param>
-    public Task ClearNamespace(long @nsId, long @lineStart, long @lineEnd) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_clear_namespace",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @nsId, @lineStart, @lineEnd)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Clears highlights and virtual text from namespace and range of lines
-    /// </para>
-    /// </summary>
-    /// <param name="nsId">
-    /// <para>
-    /// Namespace to clear, or -1 to clear all. 
-    /// </para>
-    /// </param>
-    /// <param name="lineStart">
-    /// <para>
-    /// Start of range of lines to clear 
-    /// </para>
-    /// </param>
-    /// <param name="lineEnd">
-    /// <para>
-    /// End of range of lines to clear (exclusive) or -1 to clear to end of file. 
-    /// </para>
-    /// </param>
-    public Task ClearHighlight(long @nsId, long @lineStart, long @lineEnd) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_buf_clear_highlight",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @nsId, @lineStart, @lineEnd)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Set the virtual text (annotation) for a buffer line.
-    /// </para>
-    /// </summary>
-    /// <param name="line">
-    /// <para>
-    /// Line to annotate with virtual text (zero-indexed) 
-    /// </para>
-    /// </param>
-    /// <param name="chunks">
-    /// <para>
-    /// A list of [text, hl_group] arrays, each representing a text chunk with specified highlight. 
-    /// </para>
-    /// </param>
-    /// <param name="opts">
-    /// <para>
-    /// Optional parameters. Currently not used. 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// The ns_id that was used 
-    /// </para>
-    /// </returns>
-    public Task<long> SetVirtualText(long @srcId, long @line, object[] @chunks, IDictionary @opts) =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_buf_set_virtual_text",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @srcId, @line, @chunks, @opts)
-      });
-
-  }
-  public class NvimWindow
-  {
-    private readonly NvimAPI _api;
-    private readonly MessagePackExtendedTypeObject _msgPackExtObj;
-    internal NvimWindow(NvimAPI api, MessagePackExtendedTypeObject msgPackExtObj)
-    {
-      _api = api;
-      _msgPackExtObj = msgPackExtObj;
-    }
-    
-    /// <summary>
-    /// <para>
-    /// Gets the current buffer in a window
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Buffer handle 
-    /// </para>
-    /// </returns>
-    public Task<NvimBuffer> GetBuf() =>
-      _api.SendAndReceive<NvimBuffer>(new NvimRequest
-      {
-        Method = "nvim_win_get_buf",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the current buffer in a window, without side-effects
-    /// </para>
-    /// </summary>
-    /// <param name="buffer">
-    /// <para>
-    /// Buffer handle 
-    /// </para>
-    /// </param>
-    public Task SetBuf(NvimBuffer @buffer) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_set_buf",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @buffer)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the (1,0)-indexed cursor position in the window. |api-indexing|
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// (row, col) tuple 
-    /// </para>
-    /// </returns>
-    public Task<long[]> GetCursor() =>
-      _api.SendAndReceive<long[]>(new NvimRequest
-      {
-        Method = "nvim_win_get_cursor",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the (1,0)-indexed cursor position in the window. |api-indexing|
-    /// </para>
-    /// </summary>
-    /// <param name="pos">
-    /// <para>
-    /// (row, col) tuple representing the new position 
-    /// </para>
-    /// </param>
-    public Task SetCursor(long[] @pos) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_set_cursor",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @pos)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the window height
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Height as a count of rows 
-    /// </para>
-    /// </returns>
-    public Task<long> GetHeight() =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_win_get_height",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the window height. This will only succeed if the screen is split horizontally.
-    /// </para>
-    /// </summary>
-    /// <param name="height">
-    /// <para>
-    /// Height as a count of rows 
-    /// </para>
-    /// </param>
-    public Task SetHeight(long @height) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_set_height",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @height)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the window width
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Width as a count of columns 
-    /// </para>
-    /// </returns>
-    public Task<long> GetWidth() =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_win_get_width",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets the window width. This will only succeed if the screen is split vertically.
-    /// </para>
-    /// </summary>
-    /// <param name="width">
-    /// <para>
-    /// Width as a count of columns 
-    /// </para>
-    /// </param>
-    public Task SetWidth(long @width) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_set_width",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @width)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a window-scoped (w:) variable
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </returns>
-    public Task<object> GetVar(string @name) =>
-      _api.SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_win_get_var",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets a window-scoped (w:) variable
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <param name="value">
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </param>
-    public Task SetVar(string @name, object @value) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_set_var",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name, @value)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Removes a window-scoped (w:) variable
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    public Task DelVar(string @name) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_del_var",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a window option value
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Option name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Option value 
-    /// </para>
-    /// </returns>
-    public Task<object> GetOption(string @name) =>
-      _api.SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_win_get_option",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets a window option value. Passing &apos;nil&apos; as value deletes the option(only works if there&apos;s a global fallback)
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Option name 
-    /// </para>
-    /// </param>
-    /// <param name="value">
-    /// <para>
-    /// Option value 
-    /// </para>
-    /// </param>
-    public Task SetOption(string @name, object @value) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_set_option",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name, @value)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the window position in display cells. First position is zero.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// (row, col) tuple with the window position 
-    /// </para>
-    /// </returns>
-    public Task<long[]> GetPosition() =>
-      _api.SendAndReceive<long[]>(new NvimRequest
-      {
-        Method = "nvim_win_get_position",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the window tabpage
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Tabpage that contains the window 
-    /// </para>
-    /// </returns>
-    public Task<NvimTabpage> GetTabpage() =>
-      _api.SendAndReceive<NvimTabpage>(new NvimRequest
-      {
-        Method = "nvim_win_get_tabpage",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the window number
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Window number 
-    /// </para>
-    /// </returns>
-    public Task<long> GetNumber() =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_win_get_number",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Checks if a window is valid
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// true if the window is valid, false otherwise 
-    /// </para>
-    /// </returns>
-    public Task<bool> IsValid() =>
-      _api.SendAndReceive<bool>(new NvimRequest
-      {
-        Method = "nvim_win_is_valid",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Configures window layout. Currently only for floating and external windows (including changing a split window to those layouts).
-    /// </para>
-    /// </summary>
-    /// <param name="config">
-    /// <para>
-    /// Map defining the window configuration, see |nvim_open_win()| 
-    /// </para>
-    /// </param>
-    public Task SetConfig(IDictionary @config) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_set_config",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @config)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets window configuration.
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Map defining the window configuration, see |nvim_open_win()| 
-    /// </para>
-    /// </returns>
-    public Task<IDictionary> GetConfig() =>
-      _api.SendAndReceive<IDictionary>(new NvimRequest
-      {
-        Method = "nvim_win_get_config",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Closes the window and hide the buffer it contains (like |:hide| with a |window-ID|).
-    /// </para>
-    /// </summary>
-    public Task Hide() =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_hide",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Closes the window (like |:close| with a |window-ID|).
-    /// </para>
-    /// </summary>
-    /// <param name="force">
-    /// <para>
-    /// Behave like 
-    /// </para>
-    /// </param>
-    public Task Close(bool @force) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_win_close",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @force)
-      });
-
-  }
-  public class NvimTabpage
-  {
-    private readonly NvimAPI _api;
-    private readonly MessagePackExtendedTypeObject _msgPackExtObj;
-    internal NvimTabpage(NvimAPI api, MessagePackExtendedTypeObject msgPackExtObj)
-    {
-      _api = api;
-      _msgPackExtObj = msgPackExtObj;
-    }
-    
-    /// <summary>
-    /// <para>
-    /// Gets the windows in a tabpage
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// List of windows in 
-    /// </para>
-    /// </returns>
-    public Task<NvimWindow[]> ListWins() =>
-      _api.SendAndReceive<NvimWindow[]>(new NvimRequest
-      {
-        Method = "nvim_tabpage_list_wins",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets a tab-scoped (t:) variable
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </returns>
-    public Task<object> GetVar(string @name) =>
-      _api.SendAndReceive<object>(new NvimRequest
-      {
-        Method = "nvim_tabpage_get_var",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Sets a tab-scoped (t:) variable
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    /// <param name="value">
-    /// <para>
-    /// Variable value 
-    /// </para>
-    /// </param>
-    public Task SetVar(string @name, object @value) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_tabpage_set_var",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name, @value)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Removes a tab-scoped (t:) variable
-    /// </para>
-    /// </summary>
-    /// <param name="name">
-    /// <para>
-    /// Variable name 
-    /// </para>
-    /// </param>
-    public Task DelVar(string @name) =>
-      _api.SendAndReceive(new NvimRequest
-      {
-        Method = "nvim_tabpage_del_var",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj, @name)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the current window in a tabpage
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Window handle 
-    /// </para>
-    /// </returns>
-    public Task<NvimWindow> GetWin() =>
-      _api.SendAndReceive<NvimWindow>(new NvimRequest
-      {
-        Method = "nvim_tabpage_get_win",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Gets the tabpage number
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// Tabpage number 
-    /// </para>
-    /// </returns>
-    public Task<long> GetNumber() =>
-      _api.SendAndReceive<long>(new NvimRequest
-      {
-        Method = "nvim_tabpage_get_number",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-    /// <summary>
-    /// <para>
-    /// Checks if a tabpage is valid
-    /// </para>
-    /// </summary>
-    /// <returns>
-    /// <para>
-    /// true if the tabpage is valid, false otherwise 
-    /// </para>
-    /// </returns>
-    public Task<bool> IsValid() =>
-      _api.SendAndReceive<bool>(new NvimRequest
-      {
-        Method = "nvim_tabpage_is_valid",
-        Arguments = GetRequestArguments(
-          _msgPackExtObj)
-      });
-
-  }
-
-  public class ModeInfoSetEventArgs : EventArgs
-  {
-    public bool Enabled { get; set; }
-    public object[] CursorStyles { get; set; }
-
-  }
-  public class ModeChangeEventArgs : EventArgs
-  {
-    public string Mode { get; set; }
-    public long ModeIdx { get; set; }
-
-  }
-  public class SetTitleEventArgs : EventArgs
-  {
-    public string Title { get; set; }
-
-  }
-  public class SetIconEventArgs : EventArgs
-  {
-    public string Icon { get; set; }
-
-  }
-  public class ScreenshotEventArgs : EventArgs
-  {
-    public string Path { get; set; }
-
-  }
-  public class OptionSetEventArgs : EventArgs
-  {
-    public string Name { get; set; }
-    public object Value { get; set; }
-
-  }
-  public class UpdateFgEventArgs : EventArgs
-  {
-    public long Fg { get; set; }
-
-  }
-  public class UpdateBgEventArgs : EventArgs
-  {
-    public long Bg { get; set; }
-
-  }
-  public class UpdateSpEventArgs : EventArgs
-  {
-    public long Sp { get; set; }
-
-  }
-  public class ResizeEventArgs : EventArgs
-  {
-    public long Width { get; set; }
-    public long Height { get; set; }
-
-  }
-  public class CursorGotoEventArgs : EventArgs
-  {
-    public long Row { get; set; }
-    public long Col { get; set; }
-
-  }
-  public class HighlightSetEventArgs : EventArgs
-  {
-    public IDictionary Attrs { get; set; }
-
-  }
-  public class PutEventArgs : EventArgs
-  {
-    public string Str { get; set; }
-
-  }
-  public class SetScrollRegionEventArgs : EventArgs
-  {
-    public long Top { get; set; }
-    public long Bot { get; set; }
-    public long Left { get; set; }
-    public long Right { get; set; }
-
-  }
-  public class ScrollEventArgs : EventArgs
-  {
-    public long Count { get; set; }
-
-  }
-  public class DefaultColorsSetEventArgs : EventArgs
-  {
-    public long RgbFg { get; set; }
-    public long RgbBg { get; set; }
-    public long RgbSp { get; set; }
-    public long CtermFg { get; set; }
-    public long CtermBg { get; set; }
-
-  }
-  public class HlAttrDefineEventArgs : EventArgs
-  {
-    public long Id { get; set; }
-    public IDictionary RgbAttrs { get; set; }
-    public IDictionary CtermAttrs { get; set; }
-    public object[] Info { get; set; }
-
-  }
-  public class HlGroupSetEventArgs : EventArgs
-  {
-    public string Name { get; set; }
-    public long Id { get; set; }
-
-  }
-  public class GridResizeEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-    public long Width { get; set; }
-    public long Height { get; set; }
-
-  }
-  public class GridClearEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-
-  }
-  public class GridCursorGotoEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-    public long Row { get; set; }
-    public long Col { get; set; }
-
-  }
-  public class GridLineEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-    public long Row { get; set; }
-    public long ColStart { get; set; }
-    public object[] Data { get; set; }
-
-  }
-  public class GridScrollEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-    public long Top { get; set; }
-    public long Bot { get; set; }
-    public long Left { get; set; }
-    public long Right { get; set; }
-    public long Rows { get; set; }
-    public long Cols { get; set; }
-
-  }
-  public class GridDestroyEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-
-  }
-  public class WinPosEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-    public NvimWindow Win { get; set; }
-    public long Startrow { get; set; }
-    public long Startcol { get; set; }
-    public long Width { get; set; }
-    public long Height { get; set; }
-
-  }
-  public class WinFloatPosEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-    public NvimWindow Win { get; set; }
-    public string Anchor { get; set; }
-    public long AnchorGrid { get; set; }
-    public double AnchorRow { get; set; }
-    public double AnchorCol { get; set; }
-    public bool Focusable { get; set; }
-    public long Zindex { get; set; }
-
-  }
-  public class WinExternalPosEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-    public NvimWindow Win { get; set; }
-
-  }
-  public class WinHideEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-
-  }
-  public class WinCloseEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-
-  }
-  public class MsgSetPosEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-    public long Row { get; set; }
-    public bool Scrolled { get; set; }
-    public string SepChar { get; set; }
-
-  }
-  public class WinViewportEventArgs : EventArgs
-  {
-    public long Grid { get; set; }
-    public NvimWindow Win { get; set; }
-    public long Topline { get; set; }
-    public long Botline { get; set; }
-    public long Curline { get; set; }
-    public long Curcol { get; set; }
-
-  }
-  public class PopupmenuShowEventArgs : EventArgs
-  {
-    public object[] Items { get; set; }
-    public long Selected { get; set; }
-    public long Row { get; set; }
-    public long Col { get; set; }
-    public long Grid { get; set; }
-
-  }
-  public class PopupmenuSelectEventArgs : EventArgs
-  {
-    public long Selected { get; set; }
-
-  }
-  public class TablineUpdateEventArgs : EventArgs
-  {
-    public NvimTabpage Current { get; set; }
-    public object[] Tabs { get; set; }
-    public NvimBuffer CurrentBuffer { get; set; }
-    public object[] Buffers { get; set; }
-
-  }
-  public class CmdlineShowEventArgs : EventArgs
-  {
-    public object[] Content { get; set; }
-    public long Pos { get; set; }
-    public string Firstc { get; set; }
-    public string Prompt { get; set; }
-    public long Indent { get; set; }
-    public long Level { get; set; }
-
-  }
-  public class CmdlinePosEventArgs : EventArgs
-  {
-    public long Pos { get; set; }
-    public long Level { get; set; }
-
-  }
-  public class CmdlineSpecialCharEventArgs : EventArgs
-  {
-    public string C { get; set; }
-    public bool Shift { get; set; }
-    public long Level { get; set; }
-
-  }
-  public class CmdlineHideEventArgs : EventArgs
-  {
-    public long Level { get; set; }
-
-  }
-  public class CmdlineBlockShowEventArgs : EventArgs
-  {
-    public object[] Lines { get; set; }
-
-  }
-  public class CmdlineBlockAppendEventArgs : EventArgs
-  {
-    public object[] Lines { get; set; }
-
-  }
-  public class WildmenuShowEventArgs : EventArgs
-  {
-    public object[] Items { get; set; }
-
-  }
-  public class WildmenuSelectEventArgs : EventArgs
-  {
-    public long Selected { get; set; }
-
-  }
-  public class MsgShowEventArgs : EventArgs
-  {
-    public string Kind { get; set; }
-    public object[] Content { get; set; }
-    public bool ReplaceLast { get; set; }
-
-  }
-  public class MsgShowcmdEventArgs : EventArgs
-  {
-    public object[] Content { get; set; }
-
-  }
-  public class MsgShowmodeEventArgs : EventArgs
-  {
-    public object[] Content { get; set; }
-
-  }
-  public class MsgRulerEventArgs : EventArgs
-  {
-    public object[] Content { get; set; }
-
-  }
-  public class MsgHistoryShowEventArgs : EventArgs
-  {
-    public object[] Entries { get; set; }
-
-  }
-    private void CallUIEventHandler(string eventName, object[] args)
-    {
-      switch (eventName)
-      {
-  
-      case "mode_info_set":
-          ModeInfoSetEvent?.Invoke(this, new ModeInfoSetEventArgs
-          {
-            Enabled = (bool) args[0],
-            CursorStyles = (object[]) args[1]
-          });
-          break;
-
-      case "update_menu":
-          UpdateMenuEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "busy_start":
-          BusyStartEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "busy_stop":
-          BusyStopEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "mouse_on":
-          MouseOnEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "mouse_off":
-          MouseOffEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "mode_change":
-          ModeChangeEvent?.Invoke(this, new ModeChangeEventArgs
-          {
-            Mode = (string) args[0],
-            ModeIdx = (long) args[1]
-          });
-          break;
-
-      case "bell":
-          BellEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "visual_bell":
-          VisualBellEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "flush":
-          FlushEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "suspend":
-          SuspendEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "set_title":
-          SetTitleEvent?.Invoke(this, new SetTitleEventArgs
-          {
-            Title = (string) args[0]
-          });
-          break;
-
-      case "set_icon":
-          SetIconEvent?.Invoke(this, new SetIconEventArgs
-          {
-            Icon = (string) args[0]
-          });
-          break;
-
-      case "screenshot":
-          ScreenshotEvent?.Invoke(this, new ScreenshotEventArgs
-          {
-            Path = (string) args[0]
-          });
-          break;
-
-      case "option_set":
-          OptionSetEvent?.Invoke(this, new OptionSetEventArgs
-          {
-            Name = (string) args[0],
-            Value = (object) args[1]
-          });
-          break;
-
-      case "update_fg":
-          UpdateFgEvent?.Invoke(this, new UpdateFgEventArgs
-          {
-            Fg = (long) args[0]
-          });
-          break;
-
-      case "update_bg":
-          UpdateBgEvent?.Invoke(this, new UpdateBgEventArgs
-          {
-            Bg = (long) args[0]
-          });
-          break;
-
-      case "update_sp":
-          UpdateSpEvent?.Invoke(this, new UpdateSpEventArgs
-          {
-            Sp = (long) args[0]
-          });
-          break;
-
-      case "resize":
-          ResizeEvent?.Invoke(this, new ResizeEventArgs
-          {
-            Width = (long) args[0],
-            Height = (long) args[1]
-          });
-          break;
-
-      case "clear":
-          ClearEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "eol_clear":
-          EolClearEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "cursor_goto":
-          CursorGotoEvent?.Invoke(this, new CursorGotoEventArgs
-          {
-            Row = (long) args[0],
-            Col = (long) args[1]
-          });
-          break;
-
-      case "highlight_set":
-          HighlightSetEvent?.Invoke(this, new HighlightSetEventArgs
-          {
-            Attrs = (IDictionary) args[0]
-          });
-          break;
-
-      case "put":
-          PutEvent?.Invoke(this, new PutEventArgs
-          {
-            Str = (string) args[0]
-          });
-          break;
-
-      case "set_scroll_region":
-          SetScrollRegionEvent?.Invoke(this, new SetScrollRegionEventArgs
-          {
-            Top = (long) args[0],
-            Bot = (long) args[1],
-            Left = (long) args[2],
-            Right = (long) args[3]
-          });
-          break;
-
-      case "scroll":
-          ScrollEvent?.Invoke(this, new ScrollEventArgs
-          {
-            Count = (long) args[0]
-          });
-          break;
-
-      case "default_colors_set":
-          DefaultColorsSetEvent?.Invoke(this, new DefaultColorsSetEventArgs
-          {
-            RgbFg = (long) args[0],
-            RgbBg = (long) args[1],
-            RgbSp = (long) args[2],
-            CtermFg = (long) args[3],
-            CtermBg = (long) args[4]
-          });
-          break;
-
-      case "hl_attr_define":
-          HlAttrDefineEvent?.Invoke(this, new HlAttrDefineEventArgs
-          {
-            Id = (long) args[0],
-            RgbAttrs = (IDictionary) args[1],
-            CtermAttrs = (IDictionary) args[2],
-            Info = (object[]) args[3]
-          });
-          break;
-
-      case "hl_group_set":
-          HlGroupSetEvent?.Invoke(this, new HlGroupSetEventArgs
-          {
-            Name = (string) args[0],
-            Id = (long) args[1]
-          });
-          break;
-
-      case "grid_resize":
-          GridResizeEvent?.Invoke(this, new GridResizeEventArgs
-          {
-            Grid = (long) args[0],
-            Width = (long) args[1],
-            Height = (long) args[2]
-          });
-          break;
-
-      case "grid_clear":
-          GridClearEvent?.Invoke(this, new GridClearEventArgs
-          {
-            Grid = (long) args[0]
-          });
-          break;
-
-      case "grid_cursor_goto":
-          GridCursorGotoEvent?.Invoke(this, new GridCursorGotoEventArgs
-          {
-            Grid = (long) args[0],
-            Row = (long) args[1],
-            Col = (long) args[2]
-          });
-          break;
-
-      case "grid_line":
-          GridLineEvent?.Invoke(this, new GridLineEventArgs
-          {
-            Grid = (long) args[0],
-            Row = (long) args[1],
-            ColStart = (long) args[2],
-            Data = (object[]) args[3]
-          });
-          break;
-
-      case "grid_scroll":
-          GridScrollEvent?.Invoke(this, new GridScrollEventArgs
-          {
-            Grid = (long) args[0],
-            Top = (long) args[1],
-            Bot = (long) args[2],
-            Left = (long) args[3],
-            Right = (long) args[4],
-            Rows = (long) args[5],
-            Cols = (long) args[6]
-          });
-          break;
-
-      case "grid_destroy":
-          GridDestroyEvent?.Invoke(this, new GridDestroyEventArgs
-          {
-            Grid = (long) args[0]
-          });
-          break;
-
-      case "win_pos":
-          WinPosEvent?.Invoke(this, new WinPosEventArgs
-          {
-            Grid = (long) args[0],
-            Win = (NvimWindow) args[1],
-            Startrow = (long) args[2],
-            Startcol = (long) args[3],
-            Width = (long) args[4],
-            Height = (long) args[5]
-          });
-          break;
-
-      case "win_float_pos":
-          WinFloatPosEvent?.Invoke(this, new WinFloatPosEventArgs
-          {
-            Grid = (long) args[0],
-            Win = (NvimWindow) args[1],
-            Anchor = (string) args[2],
-            AnchorGrid = (long) args[3],
-            AnchorRow = (double) args[4],
-            AnchorCol = (double) args[5],
-            Focusable = (bool) args[6],
-            Zindex = (long) args[7]
-          });
-          break;
-
-      case "win_external_pos":
-          WinExternalPosEvent?.Invoke(this, new WinExternalPosEventArgs
-          {
-            Grid = (long) args[0],
-            Win = (NvimWindow) args[1]
-          });
-          break;
-
-      case "win_hide":
-          WinHideEvent?.Invoke(this, new WinHideEventArgs
-          {
-            Grid = (long) args[0]
-          });
-          break;
-
-      case "win_close":
-          WinCloseEvent?.Invoke(this, new WinCloseEventArgs
-          {
-            Grid = (long) args[0]
-          });
-          break;
-
-      case "msg_set_pos":
-          MsgSetPosEvent?.Invoke(this, new MsgSetPosEventArgs
-          {
-            Grid = (long) args[0],
-            Row = (long) args[1],
-            Scrolled = (bool) args[2],
-            SepChar = (string) args[3]
-          });
-          break;
-
-      case "win_viewport":
-          WinViewportEvent?.Invoke(this, new WinViewportEventArgs
-          {
-            Grid = (long) args[0],
-            Win = (NvimWindow) args[1],
-            Topline = (long) args[2],
-            Botline = (long) args[3],
-            Curline = (long) args[4],
-            Curcol = (long) args[5]
-          });
-          break;
-
-      case "popupmenu_show":
-          PopupmenuShowEvent?.Invoke(this, new PopupmenuShowEventArgs
-          {
-            Items = (object[]) args[0],
-            Selected = (long) args[1],
-            Row = (long) args[2],
-            Col = (long) args[3],
-            Grid = (long) args[4]
-          });
-          break;
-
-      case "popupmenu_hide":
-          PopupmenuHideEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "popupmenu_select":
-          PopupmenuSelectEvent?.Invoke(this, new PopupmenuSelectEventArgs
-          {
-            Selected = (long) args[0]
-          });
-          break;
-
-      case "tabline_update":
-          TablineUpdateEvent?.Invoke(this, new TablineUpdateEventArgs
-          {
-            Current = (NvimTabpage) args[0],
-            Tabs = (object[]) args[1],
-            CurrentBuffer = (NvimBuffer) args[2],
-            Buffers = (object[]) args[3]
-          });
-          break;
-
-      case "cmdline_show":
-          CmdlineShowEvent?.Invoke(this, new CmdlineShowEventArgs
-          {
-            Content = (object[]) args[0],
-            Pos = (long) args[1],
-            Firstc = (string) args[2],
-            Prompt = (string) args[3],
-            Indent = (long) args[4],
-            Level = (long) args[5]
-          });
-          break;
-
-      case "cmdline_pos":
-          CmdlinePosEvent?.Invoke(this, new CmdlinePosEventArgs
-          {
-            Pos = (long) args[0],
-            Level = (long) args[1]
-          });
-          break;
-
-      case "cmdline_special_char":
-          CmdlineSpecialCharEvent?.Invoke(this, new CmdlineSpecialCharEventArgs
-          {
-            C = (string) args[0],
-            Shift = (bool) args[1],
-            Level = (long) args[2]
-          });
-          break;
-
-      case "cmdline_hide":
-          CmdlineHideEvent?.Invoke(this, new CmdlineHideEventArgs
-          {
-            Level = (long) args[0]
-          });
-          break;
-
-      case "cmdline_block_show":
-          CmdlineBlockShowEvent?.Invoke(this, new CmdlineBlockShowEventArgs
-          {
-            Lines = (object[]) args[0]
-          });
-          break;
-
-      case "cmdline_block_append":
-          CmdlineBlockAppendEvent?.Invoke(this, new CmdlineBlockAppendEventArgs
-          {
-            Lines = (object[]) args[0]
-          });
-          break;
-
-      case "cmdline_block_hide":
-          CmdlineBlockHideEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "wildmenu_show":
-          WildmenuShowEvent?.Invoke(this, new WildmenuShowEventArgs
-          {
-            Items = (object[]) args[0]
-          });
-          break;
-
-      case "wildmenu_select":
-          WildmenuSelectEvent?.Invoke(this, new WildmenuSelectEventArgs
-          {
-            Selected = (long) args[0]
-          });
-          break;
-
-      case "wildmenu_hide":
-          WildmenuHideEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "msg_show":
-          MsgShowEvent?.Invoke(this, new MsgShowEventArgs
-          {
-            Kind = (string) args[0],
-            Content = (object[]) args[1],
-            ReplaceLast = (bool) args[2]
-          });
-          break;
-
-      case "msg_clear":
-          MsgClearEvent?.Invoke(this, EventArgs.Empty);
-          break;
-
-      case "msg_showcmd":
-          MsgShowcmdEvent?.Invoke(this, new MsgShowcmdEventArgs
-          {
-            Content = (object[]) args[0]
-          });
-          break;
-
-      case "msg_showmode":
-          MsgShowmodeEvent?.Invoke(this, new MsgShowmodeEventArgs
-          {
-            Content = (object[]) args[0]
-          });
-          break;
-
-      case "msg_ruler":
-          MsgRulerEvent?.Invoke(this, new MsgRulerEventArgs
-          {
-            Content = (object[]) args[0]
-          });
-          break;
-
-      case "msg_history_show":
-          MsgHistoryShowEvent?.Invoke(this, new MsgHistoryShowEventArgs
-          {
-            Entries = (object[]) args[0]
-          });
-          break;
-
-      }
-    }
-
-    private object GetExtensionType(MessagePackExtendedTypeObject msgPackExtObj)
-    {
-      switch (msgPackExtObj.TypeCode)
-      {
-
-        case 0:
-          return new NvimBuffer(this, msgPackExtObj);
-        case 1:
-          return new NvimWindow(this, msgPackExtObj);
-        case 2:
-          return new NvimTabpage(this, msgPackExtObj);
-        default:
-          throw new SerializationException(
-            $"Unknown extension type id {msgPackExtObj.TypeCode}");
-      }
-    }
-  }
 }

--- a/src/NvimClient.API/NvimPlugin/Attributes/NvimEvalAttribute.cs
+++ b/src/NvimClient.API/NvimPlugin/Attributes/NvimEvalAttribute.cs
@@ -11,6 +11,7 @@ namespace NvimClient.API.NvimPlugin.Attributes
   public class NvimEvalAttribute : Attribute
   {
     public NvimEvalAttribute(string value) => Value = value;
+
     public string Value { get; }
   }
 }

--- a/src/NvimClient.API/NvimPlugin/NvimPluginAutoCommand.cs
+++ b/src/NvimClient.API/NvimPlugin/NvimPluginAutoCommand.cs
@@ -10,10 +10,13 @@ namespace NvimClient.API.NvimPlugin
   {
     private NvimAutocmdAttribute Attribute { get; }
 
-    public NvimPluginAutocmd(MethodInfo method, string pluginPath,
-      object pluginInstance, NvimAutocmdAttribute attribute) : base(
-      attribute.Name ?? method.Name, method, pluginPath,
-      pluginInstance)
+    public NvimPluginAutocmd(
+      MethodInfo method,
+      string pluginPath,
+      object pluginInstance,
+      NvimAutocmdAttribute attribute
+    )
+      : base(attribute.Name ?? method.Name, method, pluginPath, pluginInstance)
     {
       var evalParameterIndices = new List<int>(Method.GetParameters().Length);
       var attributeVisitors = new Dictionary<Type, Action<int, object>>
@@ -21,28 +24,24 @@ namespace NvimClient.API.NvimPlugin
         {
           typeof(NvimEvalAttribute),
           (index, attr) => evalParameterIndices.Add(index)
-        }
+        },
       };
       VisitParameters(new Dictionary<Type, Action<int>>(), attributeVisitors);
 
       var argumentConverters = new List<ArgumentConverter>();
       if (evalParameterIndices.Any())
       {
-        argumentConverters.Add(
-          nvimArg => evalParameterIndices.Zip(
-            (object[])nvimArg, (index, arg) =>
-             new PluginArgument
-             {
-               Value = arg,
-               Index = index
-             })
+        argumentConverters.Add(nvimArg =>
+          evalParameterIndices.Zip(
+            (object[])nvimArg,
+            (index, arg) => new PluginArgument { Value = arg, Index = index }
+          )
         );
       }
 
       Attribute = attribute;
       ArgumentConverters = argumentConverters;
     }
-
 
     public override string HandlerName =>
       $"{PluginPath}:autocmd:{Name}:{Attribute.Pattern}";
@@ -69,12 +68,12 @@ namespace NvimClient.API.NvimPlugin
       AddEvalOption(opts);
 
       return new Dictionary<string, object>
-             {
-               {"type", "autocmd"},
-               {"name", Name},
-               {"sync", Sync ? "1" : "0"},
-               {"opts", opts}
-             };
+      {
+        { "type", "autocmd" },
+        { "name", Name },
+        { "sync", Sync ? "1" : "0" },
+        { "opts", opts },
+      };
     }
   }
 }

--- a/src/NvimClient.API/NvimPlugin/NvimPluginCommand.cs
+++ b/src/NvimClient.API/NvimPlugin/NvimPluginCommand.cs
@@ -10,27 +10,40 @@ namespace NvimClient.API.NvimPlugin
   internal class NvimPluginCommand : NvimPluginExport
   {
     private static readonly string[] AllowedNArgsValues =
-      {"0", "1", "*", "?", "+"};
-
-    public NvimPluginCommand(MethodInfo method, string pluginPath,
-      object pluginInstance, NvimCommandAttribute attribute) : base(
-      attribute.Name ?? method.Name, method, pluginPath, pluginInstance)
     {
-      if (!string.IsNullOrEmpty(attribute.NArgs) &&
-          !AllowedNArgsValues.Contains(attribute.NArgs))
+      "0",
+      "1",
+      "*",
+      "?",
+      "+",
+    };
+
+    public NvimPluginCommand(
+      MethodInfo method,
+      string pluginPath,
+      object pluginInstance,
+      NvimCommandAttribute attribute
+    )
+      : base(attribute.Name ?? method.Name, method, pluginPath, pluginInstance)
+    {
+      if (
+        !string.IsNullOrEmpty(attribute.NArgs)
+        && !AllowedNArgsValues.Contains(attribute.NArgs)
+      )
       {
         throw new Exception(
-          $"The value of {nameof(attribute.NArgs)} is invalid");
+          $"The value of {nameof(attribute.NArgs)} is invalid"
+        );
       }
 
       int? functionParameterIndex = null;
       var parameterVisitors = new Dictionary<Type, Action<int>>
       {
-        {typeof(NvimBang), index => BangParameterIndex = index},
-        {typeof(NvimCount), index => CountParameterIndex = index},
-        {typeof(NvimRange), index => RangeParameterIndex = index},
-        {typeof(NvimRegister), index => RegisterParameterIndex = index},
-        {typeof(object), index => functionParameterIndex = index}
+        { typeof(NvimBang), index => BangParameterIndex = index },
+        { typeof(NvimCount), index => CountParameterIndex = index },
+        { typeof(NvimRange), index => RangeParameterIndex = index },
+        { typeof(NvimRegister), index => RegisterParameterIndex = index },
+        { typeof(object), index => functionParameterIndex = index },
       };
       var evalParameterIndices = new List<int>(Method.GetParameters().Length);
       var attributeVisitors = new Dictionary<Type, Action<int, object>>
@@ -38,14 +51,15 @@ namespace NvimClient.API.NvimPlugin
         {
           typeof(NvimEvalAttribute),
           (index, attr) => evalParameterIndices.Add(index)
-        }
+        },
       };
       VisitParameters(parameterVisitors, attributeVisitors);
 
       if (CountParameterIndex.HasValue && RangeParameterIndex.HasValue)
       {
         throw new ArgumentException(
-          "Range and Count parameters are mutually exclusive");
+          "Range and Count parameters are mutually exclusive"
+        );
       }
 
       var argumentConverters = new List<ArgumentConverter>();
@@ -59,35 +73,40 @@ namespace NvimClient.API.NvimPlugin
         {
           throw new Exception(
             $"Parameter \"{functionParameter.Name}\" of type string is only"
-            + $" allowed when {nameof(attribute.NArgs)} is \"1\" or \"?\"");
+              + $" allowed when {nameof(attribute.NArgs)} is \"1\" or \"?\""
+          );
         }
 
-        argumentConverters.Add(
-          arg => new[]
+        argumentConverters.Add(arg =>
+          new[]
           {
             new PluginArgument
             {
-              Value = ((object[]) arg).First(),
-              Index = functionParameterIndex.Value
-            }
-          });
+              Value = ((object[])arg).First(),
+              Index = functionParameterIndex.Value,
+            },
+          }
+        );
       }
       else if (paramType == typeof(string[]))
       {
-        argumentConverters.Add(
-          arg => new[]
+        argumentConverters.Add(arg =>
+          new[]
           {
             new PluginArgument
             {
-              Value = ((object[]) arg).Cast<string>().ToArray(),
-              Index = functionParameterIndex.Value
-            }
-          });
+              Value = ((object[])arg).Cast<string>().ToArray(),
+              Index = functionParameterIndex.Value,
+            },
+          }
+        );
       }
       else if (paramType != null)
       {
-        throw new Exception($"Parameter \"{functionParameter.Name}\" must"
-                            + " be of type string or string[]");
+        throw new Exception(
+          $"Parameter \"{functionParameter.Name}\" must"
+            + " be of type string or string[]"
+        );
       }
 
       if (RangeParameterIndex.HasValue)
@@ -103,58 +122,61 @@ namespace NvimClient.API.NvimPlugin
               Value = new NvimRange
               {
                 FirstLine = range[0],
-                LastLine  = range[1]
-              }
-            }
+                LastLine = range[1],
+              },
+            },
           };
         });
       }
       else if (CountParameterIndex.HasValue)
       {
-        argumentConverters.Add(arg => new[]
-        {
-          new PluginArgument
+        argumentConverters.Add(arg =>
+          new[]
           {
-            Index = CountParameterIndex.Value,
-            Value = new NvimCount((long) arg)
+            new PluginArgument
+            {
+              Index = CountParameterIndex.Value,
+              Value = new NvimCount((long)arg),
+            },
           }
-        });
+        );
       }
 
       if (BangParameterIndex.HasValue)
       {
-        argumentConverters.Add(arg => new[]
-        {
-          new PluginArgument
+        argumentConverters.Add(arg =>
+          new[]
           {
-            Index = BangParameterIndex.Value,
-            Value = new NvimBang(Convert.ToBoolean(arg))
+            new PluginArgument
+            {
+              Index = BangParameterIndex.Value,
+              Value = new NvimBang(Convert.ToBoolean(arg)),
+            },
           }
-        });
+        );
       }
 
       if (RegisterParameterIndex.HasValue)
       {
-        argumentConverters.Add(arg => new[]
-        {
-          new PluginArgument
+        argumentConverters.Add(arg =>
+          new[]
           {
-            Index = RegisterParameterIndex.Value,
-            Value = new NvimRegister((string) arg)
+            new PluginArgument
+            {
+              Index = RegisterParameterIndex.Value,
+              Value = new NvimRegister((string)arg),
+            },
           }
-        });
+        );
       }
 
       if (evalParameterIndices.Any())
       {
-        argumentConverters.Add(
-          nvimArg => evalParameterIndices.Zip(
-            (object[])nvimArg, (index, arg) =>
-             new PluginArgument
-             {
-               Value = arg,
-               Index = index
-             })
+        argumentConverters.Add(nvimArg =>
+          evalParameterIndices.Zip(
+            (object[])nvimArg,
+            (index, arg) => new PluginArgument { Value = arg, Index = index }
+          )
         );
       }
 
@@ -222,10 +244,10 @@ namespace NvimClient.API.NvimPlugin
 
       return new Dictionary<string, object>
       {
-        {"type", "command"},
-        {"name", Name},
-        {"sync", Sync ? "1" : "0"},
-        {"opts", opts}
+        { "type", "command" },
+        { "name", Name },
+        { "sync", Sync ? "1" : "0" },
+        { "opts", opts },
       };
     }
   }

--- a/src/NvimClient.API/NvimPlugin/NvimPluginExport.cs
+++ b/src/NvimClient.API/NvimPlugin/NvimPluginExport.cs
@@ -11,25 +11,27 @@ namespace NvimClient.API.NvimPlugin
 {
   public abstract class NvimPluginExport
   {
-    protected NvimPluginExport(string name, MethodInfo method,
-      string pluginPath, object pluginInstance)
+    protected NvimPluginExport(
+      string name,
+      MethodInfo method,
+      string pluginPath,
+      object pluginInstance
+    )
     {
       Name = name;
       Method = method;
       PluginPath = pluginPath;
       PluginInstance = pluginInstance;
-      Sync = method.GetCustomAttribute<AsyncStateMachineAttribute>() == null
-             && method.ReturnType != typeof(Task)
-             && (!method.ReturnType.IsGenericType
-                 || method.ReturnType.GetGenericTypeDefinition()
-                 != typeof(Task<>));
+      Sync =
+        method.GetCustomAttribute<AsyncStateMachineAttribute>() == null
+        && method.ReturnType != typeof(Task)
+        && (
+          !method.ReturnType.IsGenericType
+          || method.ReturnType.GetGenericTypeDefinition() != typeof(Task<>)
+        );
     }
 
-    protected IReadOnlyCollection<ArgumentConverter> ArgumentConverters
-    {
-      get;
-      set;
-    }
+    protected IReadOnlyCollection<ArgumentConverter> ArgumentConverters { get; set; }
 
     internal bool Sync { get; }
     public abstract string HandlerName { get; }
@@ -39,26 +41,32 @@ namespace NvimClient.API.NvimPlugin
     public string Name { get; }
 
     public Func<object[], object> Handler =>
-      args => Method.Invoke(PluginInstance,
-        ConvertPluginArguments(args).ToArray());
+      args =>
+        Method.Invoke(PluginInstance, ConvertPluginArguments(args).ToArray());
 
     internal abstract Dictionary<string, object> GetSpec();
 
     internal void Register(NvimAPI nvim) =>
       nvim.RegisterHandler(HandlerName, Handler);
 
-    private IEnumerable<object>
-      ConvertPluginArguments(IEnumerable<object> nvimArguments) =>
-      ArgumentConverters.Zip(nvimArguments, (converter, arg) => converter(arg))
-        .SelectMany(arg => arg).OrderBy(arg => arg.Index)
+    private IEnumerable<object> ConvertPluginArguments(
+      IEnumerable<object> nvimArguments
+    ) =>
+      ArgumentConverters
+        .Zip(nvimArguments, (converter, arg) => converter(arg))
+        .SelectMany(arg => arg)
+        .OrderBy(arg => arg.Index)
         .Select(arg => arg.Value);
 
     protected void AddEvalOption(Dictionary<string, string> opts)
     {
-      var evalExpressions = string.Join(",", Method.GetParameters().Select(
-          param =>
-            param.GetCustomAttribute<NvimEvalAttribute>()?.Value)
-        .Where(eval => eval != null));
+      var evalExpressions = string.Join(
+        ",",
+        Method
+          .GetParameters()
+          .Select(param => param.GetCustomAttribute<NvimEvalAttribute>()?.Value)
+          .Where(eval => eval != null)
+      );
       if (!string.IsNullOrEmpty(evalExpressions))
       {
         opts["eval"] = $"[{evalExpressions}]";
@@ -77,38 +85,53 @@ namespace NvimClient.API.NvimPlugin
     /// </param>
     protected void VisitParameters(
       IReadOnlyDictionary<Type, Action<int>> typeVisitors,
-      IReadOnlyDictionary<Type, Action<int, object>> attributeVisitors)
+      IReadOnlyDictionary<Type, Action<int, object>> attributeVisitors
+    )
     {
-      foreach (var param in Method.GetParameters()
-        .Select((param, index) =>
-          new
-          {
-            Index = index,
-            Type = param.ParameterType,
-            Attributes = param.GetCustomAttributes()
-          }))
+      foreach (
+        var param in Method
+          .GetParameters()
+          .Select(
+            (param, index) =>
+              new
+              {
+                Index = index,
+                Type = param.ParameterType,
+                Attributes = param.GetCustomAttributes(),
+              }
+          )
+      )
       {
         var isValidAPIType = NvimTypesMap.IsValidType(param.Type);
-        var isValidPluginType =
-          typeVisitors.TryGetValue(param.Type, out var visitor);
+        var isValidPluginType = typeVisitors.TryGetValue(
+          param.Type,
+          out var visitor
+        );
         if (!isValidAPIType && !isValidPluginType)
         {
           throw new Exception(
-            $"Plugin export has invalid parameter type \"{param.Type.Name}\"");
+            $"Plugin export has invalid parameter type \"{param.Type.Name}\""
+          );
         }
 
-        if (visitor != null
-            // If there is not a visitor for the specific type,
-            // try to use the "object" visitor as a default
-            || typeVisitors.TryGetValue(typeof(object), out visitor))
+        if (
+          visitor != null
+          // If there is not a visitor for the specific type,
+          // try to use the "object" visitor as a default
+          || typeVisitors.TryGetValue(typeof(object), out visitor)
+        )
         {
           visitor(param.Index);
         }
 
         foreach (var attribute in param.Attributes)
         {
-          if (attributeVisitors.TryGetValue(attribute.GetType(),
-            out var attributeVisitor))
+          if (
+            attributeVisitors.TryGetValue(
+              attribute.GetType(),
+              out var attributeVisitor
+            )
+          )
           {
             attributeVisitor(param.Index, attribute);
           }
@@ -128,6 +151,7 @@ namespace NvimClient.API.NvimPlugin
     /// <param name="nvimArgument">Argument from Nvim.</param>
     /// <returns>Arguments to invoke the plugin method with.</returns>
     protected delegate IEnumerable<PluginArgument> ArgumentConverter(
-      object nvimArgument);
+      object nvimArgument
+    );
   }
 }

--- a/src/NvimClient.API/NvimPlugin/NvimPluginFunction.cs
+++ b/src/NvimClient.API/NvimPlugin/NvimPluginFunction.cs
@@ -9,22 +9,27 @@ namespace NvimClient.API.NvimPlugin
 {
   internal class NvimPluginFunction : NvimPluginExport
   {
-    internal NvimPluginFunction(MethodInfo method, string pluginPath,
-      object pluginInstance, NvimFunctionAttribute attribute) : base(
-      attribute.Name ?? method.Name, method, pluginPath, pluginInstance)
+    internal NvimPluginFunction(
+      MethodInfo method,
+      string pluginPath,
+      object pluginInstance,
+      NvimFunctionAttribute attribute
+    )
+      : base(attribute.Name ?? method.Name, method, pluginPath, pluginInstance)
     {
-      var functionParameterIndices =
-        new List<int>(Method.GetParameters().Length);
+      var functionParameterIndices = new List<int>(
+        Method.GetParameters().Length
+      );
       var parameterVisitors = new Dictionary<Type, Action<int>>
       {
-        {
-          typeof(NvimRange),
-          index => RangeParameterIndex = index
-        },
+        { typeof(NvimRange), index => RangeParameterIndex = index },
         {
           typeof(object),
-          index => { functionParameterIndices.Add(index); }
-        }
+          index =>
+          {
+            functionParameterIndices.Add(index);
+          }
+        },
       };
       var evalParameterIndices = new List<int>(Method.GetParameters().Length);
       var attributeVisitors = new Dictionary<Type, Action<int, object>>
@@ -32,19 +37,17 @@ namespace NvimClient.API.NvimPlugin
         {
           typeof(NvimEvalAttribute),
           (index, attr) => evalParameterIndices.Add(index)
-        }
+        },
       };
       VisitParameters(parameterVisitors, attributeVisitors);
 
       var argumentConverters = new List<ArgumentConverter>
       {
-        nvimArg => functionParameterIndices.Zip(
-          (object[]) nvimArg, (index, arg) =>
-            new PluginArgument
-            {
-              Value = arg,
-              Index = index
-            })
+        nvimArg =>
+          functionParameterIndices.Zip(
+            (object[])nvimArg,
+            (index, arg) => new PluginArgument { Value = arg, Index = index }
+          ),
       };
       if (RangeParameterIndex.HasValue)
       {
@@ -59,23 +62,20 @@ namespace NvimClient.API.NvimPlugin
               Value = new NvimRange
               {
                 FirstLine = range[0],
-                LastLine  = range[1]
-              }
-            }
+                LastLine = range[1],
+              },
+            },
           };
         });
       }
 
       if (evalParameterIndices.Any())
       {
-        argumentConverters.Add(
-          nvimArg => evalParameterIndices.Zip(
-            (object[])nvimArg, (index, arg) =>
-             new PluginArgument
-             {
-               Value = arg,
-               Index = index
-             })
+        argumentConverters.Add(nvimArg =>
+          evalParameterIndices.Zip(
+            (object[])nvimArg,
+            (index, arg) => new PluginArgument { Value = arg, Index = index }
+          )
         );
       }
 
@@ -101,10 +101,10 @@ namespace NvimClient.API.NvimPlugin
 
       return new Dictionary<string, object>
       {
-        {"type", "function"},
-        {"name", Name},
-        {"sync", Sync ? "1" : "0"},
-        {"opts", opts}
+        { "type", "function" },
+        { "name", Name },
+        { "sync", Sync ? "1" : "0" },
+        { "opts", opts },
       };
     }
   }

--- a/src/NvimClient.API/NvimPlugin/Parameters/NvimBang.cs
+++ b/src/NvimClient.API/NvimPlugin/Parameters/NvimBang.cs
@@ -3,6 +3,7 @@ namespace NvimClient.API.NvimPlugin.Parameters
   public class NvimBang
   {
     private readonly bool _value;
+
     internal NvimBang(bool value) => _value = value;
 
     public static implicit operator bool(NvimBang bang) => bang._value;

--- a/src/NvimClient.API/NvimPlugin/Parameters/NvimCount.cs
+++ b/src/NvimClient.API/NvimPlugin/Parameters/NvimCount.cs
@@ -3,6 +3,7 @@ namespace NvimClient.API.NvimPlugin.Parameters
   public class NvimCount
   {
     private readonly long _value;
+
     internal NvimCount(long value) => _value = value;
 
     public static implicit operator long(NvimCount count) => count._value;

--- a/src/NvimClient.API/NvimPlugin/Parameters/NvimRegister.cs
+++ b/src/NvimClient.API/NvimPlugin/Parameters/NvimRegister.cs
@@ -3,6 +3,7 @@ namespace NvimClient.API.NvimPlugin.Parameters
   public class NvimRegister
   {
     private readonly string _value;
+
     internal NvimRegister(string value) => _value = value;
 
     public static implicit operator string(NvimRegister register) =>

--- a/src/NvimClient.API/NvimPlugin/PluginHost.cs
+++ b/src/NvimClient.API/NvimPlugin/PluginHost.cs
@@ -11,19 +11,24 @@ namespace NvimClient.API.NvimPlugin
   {
     private const string PluginHostName = "dotnet";
 
-    public static async Task
-      RegisterPlugin<T>(NvimAPI api, string pluginPath) =>
-      await RegisterPlugin(api, pluginPath, typeof(T));
+    public static async Task RegisterPlugin<T>(
+      NvimAPI api,
+      string pluginPath
+    ) => await RegisterPlugin(api, pluginPath, typeof(T));
 
-    public static async Task RegisterPlugin(NvimAPI api, string pluginPath,
-      Type pluginType)
+    public static async Task RegisterPlugin(
+      NvimAPI api,
+      string pluginPath,
+      Type pluginType
+    )
     {
       var pluginAttribute =
         pluginType.GetCustomAttribute<NvimPluginAttribute>();
       if (pluginAttribute == null)
       {
         throw new Exception(
-          $"Type \"{pluginType}\" must have the NvimPlugin attribute");
+          $"Type \"{pluginType}\" must have the NvimPlugin attribute"
+        );
       }
 
       var pluginInstance = Activator.CreateInstance(pluginType, api);
@@ -36,46 +41,52 @@ namespace NvimClient.API.NvimPlugin
         export.Register(api);
         if (export is NvimPluginFunction function)
         {
-          methodsDictionary[function.Name] =
-            new Dictionary<string, object>
-            {
-              {"async", !function.Sync},
-              {"nargs", function.Method.GetParameters().Length}
-            };
+          methodsDictionary[function.Name] = new Dictionary<string, object>
+          {
+            { "async", !function.Sync },
+            { "nargs", function.Method.GetParameters().Length },
+          };
         }
       }
 
       await RegisterPlugin(api, pluginPath, exports);
 
       var version = new Version(pluginAttribute.Version);
-      await api.SetClientInfo(pluginAttribute.Name ?? pluginType.Name,
+      await api.SetClientInfo(
+        pluginAttribute.Name ?? pluginType.Name,
         new Dictionary<string, int>
         {
-          {"major", version.Major},
-          {"minor", version.Minor},
-          {"patch", version.Build}
-        }, "plugin", methodsDictionary,
+          { "major", version.Major },
+          { "minor", version.Minor },
+          { "patch", version.Build },
+        },
+        "plugin",
+        methodsDictionary,
         new Dictionary<string, string>
         {
-          {"website", pluginAttribute.Website},
-          {"license", pluginAttribute.License},
-          {"logo", pluginAttribute.Logo}
-        });
+          { "website", pluginAttribute.Website },
+          { "license", pluginAttribute.License },
+          { "logo", pluginAttribute.Logo },
+        }
+      );
 
       var channelID = (long)(await api.GetApiInfo())[0];
-      await api.CallFunction("remote#host#Register",
-        new object[]
-        {
-          PluginHostName, "*", channelID
-        });
+      await api.CallFunction(
+        "remote#host#Register",
+        new object[] { PluginHostName, "*", channelID }
+      );
     }
 
-    public static IReadOnlyCollection<Dictionary<string, object>>
-      GetPluginSpecs(Type type) => GetPluginExports(type, null, null)
-      .Select(x => x.GetSpec()).ToArray();
+    public static IReadOnlyCollection<
+      Dictionary<string, object>
+    > GetPluginSpecs(Type type) =>
+      GetPluginExports(type, null, null).Select(x => x.GetSpec()).ToArray();
 
-    public static NvimPluginExport[] RegisterPluginExports(NvimAPI api, string pluginPath,
-      Type pluginType)
+    public static NvimPluginExport[] RegisterPluginExports(
+      NvimAPI api,
+      string pluginPath,
+      Type pluginType
+    )
     {
       var pluginInstance = Activator.CreateInstance(pluginType, api);
       var exports = GetPluginExports(pluginType, pluginPath, pluginInstance)
@@ -89,7 +100,10 @@ namespace NvimClient.API.NvimPlugin
     }
 
     private static IEnumerable<NvimPluginExport> GetPluginExports(
-      Type pluginType, string pluginPath, object pluginInstance)
+      Type pluginType,
+      string pluginPath,
+      object pluginInstance
+    )
     {
       foreach (var method in pluginType.GetMethods())
       {
@@ -97,37 +111,55 @@ namespace NvimClient.API.NvimPlugin
           method.GetCustomAttribute<NvimFunctionAttribute>();
         if (functionAttribute != null)
         {
-          yield return new NvimPluginFunction(method, pluginPath,
-            pluginInstance, functionAttribute);
+          yield return new NvimPluginFunction(
+            method,
+            pluginPath,
+            pluginInstance,
+            functionAttribute
+          );
         }
 
         var commandAttribute =
           method.GetCustomAttribute<NvimCommandAttribute>();
         if (commandAttribute != null)
         {
-          yield return new NvimPluginCommand(method, pluginPath, pluginInstance,
-            commandAttribute);
+          yield return new NvimPluginCommand(
+            method,
+            pluginPath,
+            pluginInstance,
+            commandAttribute
+          );
         }
 
         var autocmdAttribute =
           method.GetCustomAttribute<NvimAutocmdAttribute>();
         if (autocmdAttribute != null)
         {
-          yield return new NvimPluginAutocmd(method, pluginPath, pluginInstance,
-            autocmdAttribute);
+          yield return new NvimPluginAutocmd(
+            method,
+            pluginPath,
+            pluginInstance,
+            autocmdAttribute
+          );
         }
       }
     }
 
-    private static async Task RegisterPlugin(NvimAPI api, string pluginPath,
-      IEnumerable<NvimPluginExport> exports)
+    private static async Task RegisterPlugin(
+      NvimAPI api,
+      string pluginPath,
+      IEnumerable<NvimPluginExport> exports
+    )
     {
-      await api.CallFunction("remote#host#RegisterPlugin",
+      await api.CallFunction(
+        "remote#host#RegisterPlugin",
         new object[]
         {
-          PluginHostName, pluginPath,
-          exports.Select(export => export.GetSpec()).ToArray()
-        });
+          PluginHostName,
+          pluginPath,
+          exports.Select(export => export.GetSpec()).ToArray(),
+        }
+      );
     }
   }
 }

--- a/src/NvimClient.API/NvimUnhandledNotificationEventArgs.cs
+++ b/src/NvimClient.API/NvimUnhandledNotificationEventArgs.cs
@@ -4,8 +4,10 @@ namespace NvimClient.API
 {
   public class NvimUnhandledNotificationEventArgs : EventArgs
   {
-    internal NvimUnhandledNotificationEventArgs(string methodName,
-      object[] arguments)
+    internal NvimUnhandledNotificationEventArgs(
+      string methodName,
+      object[] arguments
+    )
     {
       MethodName = methodName;
       Arguments = arguments;

--- a/src/NvimClient.API/NvimUnhandledRequestEventArgs.cs
+++ b/src/NvimClient.API/NvimUnhandledRequestEventArgs.cs
@@ -6,8 +6,12 @@ namespace NvimClient.API
   {
     private readonly NvimAPI _nvim;
 
-    internal NvimUnhandledRequestEventArgs(NvimAPI nvim, uint requestId,
-      string methodName, object[] arguments)
+    internal NvimUnhandledRequestEventArgs(
+      NvimAPI nvim,
+      uint requestId,
+      string methodName,
+      object[] arguments
+    )
     {
       _nvim = nvim;
       RequestId = requestId;

--- a/src/NvimClient.API/UnixDomainSocketEndPoint.cs
+++ b/src/NvimClient.API/UnixDomainSocketEndPoint.cs
@@ -21,7 +21,8 @@ namespace NvimClient.API
     private static readonly Encoding s_pathEncoding = Encoding.UTF8;
     private static readonly int s_nativePathOffset = 2; // = offsetof(struct sockaddr_un, sun_path). It's the same on Linux and OSX
     private static readonly int s_nativePathLength = 91; // sockaddr_un.sun_path at http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_un.h.html, -1 for terminator
-    private static readonly int s_nativeAddressSize = s_nativePathOffset + s_nativePathLength;
+    private static readonly int s_nativeAddressSize =
+      s_nativePathOffset + s_nativePathLength;
 
     private readonly string _path;
     private readonly byte[] _encodedPath;
@@ -49,8 +50,10 @@ namespace NvimClient.API
         throw new ArgumentNullException(nameof(socketAddress));
       }
 
-      if (socketAddress.Family != EndPointAddressFamily ||
-          socketAddress.Size > s_nativeAddressSize)
+      if (
+        socketAddress.Family != EndPointAddressFamily
+        || socketAddress.Size > s_nativeAddressSize
+      )
       {
         throw new ArgumentOutOfRangeException(nameof(socketAddress));
       }
@@ -75,7 +78,10 @@ namespace NvimClient.API
     public override SocketAddress Serialize()
     {
       var result = new SocketAddress(AddressFamily.Unix, s_nativeAddressSize);
-      Debug.Assert(_encodedPath.Length + s_nativePathOffset <= result.Size, "Expected path to fit in address");
+      Debug.Assert(
+        _encodedPath.Length + s_nativePathOffset <= result.Size,
+        "Expected path to fit in address"
+      );
 
       for (int index = 0; index < _encodedPath.Length; index++)
       {
@@ -86,7 +92,8 @@ namespace NvimClient.API
       return result;
     }
 
-    public override EndPoint Create(SocketAddress socketAddress) => new UnixDomainSocketEndPoint(socketAddress);
+    public override EndPoint Create(SocketAddress socketAddress) =>
+      new UnixDomainSocketEndPoint(socketAddress);
 
     public override AddressFamily AddressFamily => EndPointAddressFamily;
 

--- a/src/NvimClient.APIGenerator/CSharpierExtensions.cs
+++ b/src/NvimClient.APIGenerator/CSharpierExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using CSharpier.Core;
+using Microsoft.CodeAnalysis;
+
+internal static class CSharpierExtensions
+{
+  extension(CodeFormatterResult codeFormatterResult)
+  {
+    public CSharpierResult ToCSharpierResult()
+    {
+      Exception[] errors = codeFormatterResult
+        .CompilationErrors.Where(error =>
+          error.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error
+        )
+        .Select(error => new Exception(error.ToString()))
+        .ToArray();
+      return errors.Any()
+        ? CSharpierResult.Failure(new(errors))
+        : CSharpierResult.Success(codeFormatterResult.Code);
+    }
+  }
+}
+
+internal readonly record struct CSharpierResult
+{
+  public string Code { get; }
+  public AggregateException? Exception { get; }
+  public bool IsExceptional { get; }
+
+  private CSharpierResult(
+    string code,
+    AggregateException? exception,
+    bool isExceptional
+  )
+  {
+    Code = code;
+    Exception = exception;
+    IsExceptional = isExceptional;
+  }
+
+  public static CSharpierResult Success(string code) => new(code, null, false);
+
+  public static CSharpierResult Failure(AggregateException exception) =>
+    new(string.Empty, exception, true);
+}

--- a/src/NvimClient.APIGenerator/Docs/DocElement.cs
+++ b/src/NvimClient.APIGenerator/Docs/DocElement.cs
@@ -1,6 +1,4 @@
 namespace NvimClient.APIGenerator.Docs
 {
-  public interface IDocElement
-  {
-  }
+  public interface IDocElement { }
 }

--- a/src/NvimClient.APIGenerator/Docs/DocListType.cs
+++ b/src/NvimClient.APIGenerator/Docs/DocListType.cs
@@ -3,6 +3,6 @@ namespace NvimClient.APIGenerator.Docs
   internal enum DocListType
   {
     ItemizedList,
-    OrderedList
+    OrderedList,
   }
 }

--- a/src/NvimClient.APIGenerator/Docs/DoxygenParser.cs
+++ b/src/NvimClient.APIGenerator/Docs/DoxygenParser.cs
@@ -21,8 +21,10 @@ namespace NvimClient.APIGenerator.Docs
     public DoxygenParser(string nvimSrcDirectory)
     {
       _nvimSrcDirectory = nvimSrcDirectory;
-      _tempOutputDirectory =
-        Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+      _tempOutputDirectory = Path.Combine(
+        Path.GetTempPath(),
+        Path.GetRandomFileName()
+      );
       Directory.CreateDirectory(_tempOutputDirectory);
     }
 
@@ -35,7 +37,8 @@ namespace NvimClient.APIGenerator.Docs
       catch
       {
         Console.WriteLine(
-          $"Failed to delete temporary directory: {_tempOutputDirectory}");
+          $"Failed to delete temporary directory: {_tempOutputDirectory}"
+        );
       }
     }
 
@@ -44,52 +47,65 @@ namespace NvimClient.APIGenerator.Docs
       GenerateDocumentation();
 
       var xmlDocsDirectory = Path.Combine(_tempOutputDirectory, "xml");
-      var indexXml =
-        XDocument.Load(Path.Combine(xmlDocsDirectory, "index.xml"));
+      var indexXml = XDocument.Load(
+        Path.Combine(xmlDocsDirectory, "index.xml")
+      );
       var xmlFilenames = indexXml
         .Descendants("compound")
-        .Where(node =>
-          node.Attribute("kind")?.Value == "file")
-        .Where(node =>
-          node.Element("name")?.Value.EndsWith(".c")
-          ?? false).Select(node =>
-          node.Attribute("refid")?.Value);
+        .Where(node => node.Attribute("kind")?.Value == "file")
+        .Where(node => node.Element("name")?.Value.EndsWith(".c") ?? false)
+        .Select(node => node.Attribute("refid")?.Value);
       foreach (var xmlFilename in xmlFilenames)
       {
-        var docXml =
-          XDocument.Load(Path.Combine(xmlDocsDirectory, xmlFilename + ".xml"));
-        var functionDocs = docXml.Descendants("memberdef")
+        var docXml = XDocument.Load(
+          Path.Combine(xmlDocsDirectory, xmlFilename + ".xml")
+        );
+        var functionDocs = docXml
+          .Descendants("memberdef")
           .Where(memberDef =>
             memberDef.Attribute("kind")?.Value == "function"
-            && memberDef.Attribute("static")?.Value == "no").Select(
-            memberDef => new FunctionDoc
-            {
-              Function = memberDef.Element("name").Value,
-              Summary = GetDocElements(memberDef.Element("detaileddescription")
+            && memberDef.Attribute("static")?.Value == "no"
+          )
+          .Select(memberDef => new FunctionDoc
+          {
+            Function = memberDef.Element("name").Value,
+            Summary = GetDocElements(
+              memberDef
+                .Element("detaileddescription")
                 .Elements("para")
-                .Where(para => para.Element("parameterlist") == null)),
-              Parameters = memberDef
-                             .Descendants("parameterlist")
-                             .FirstOrDefault()
-                             ?.Elements("parameteritem").Select(
-                               param => new ParameterDoc
-                               {
-                                 Name = param.Descendants("parametername")
-                                   .First().Value,
-                                 Description =
-                                   GetDocElements(param
-                                     .Descendants("parameterdescription")
-                                     .First().Nodes())
-                               }) ?? Enumerable.Empty<ParameterDoc>(),
-              Return = GetDocElements(memberDef.Element("detaileddescription")
-                ?.Descendants("simplesect").FirstOrDefault(simplesect =>
-                  simplesect.Attribute("kind")?.Value == "return")
-                ?.Nodes()),
-              Notes = GetDocElements(memberDef.Element("detaileddescription")
-                ?.Descendants("simplesect").Where(simplesect =>
-                  simplesect.Attribute("kind")?.Value == "note"))
-            }
-          );
+                .Where(para => para.Element("parameterlist") == null)
+            ),
+            Parameters =
+              memberDef
+                .Descendants("parameterlist")
+                .FirstOrDefault()
+                ?.Elements("parameteritem")
+                .Select(param => new ParameterDoc
+                {
+                  Name = param.Descendants("parametername").First().Value,
+                  Description = GetDocElements(
+                    param.Descendants("parameterdescription").First().Nodes()
+                  ),
+                })
+              ?? Enumerable.Empty<ParameterDoc>(),
+            Return = GetDocElements(
+              memberDef
+                .Element("detaileddescription")
+                ?.Descendants("simplesect")
+                .FirstOrDefault(simplesect =>
+                  simplesect.Attribute("kind")?.Value == "return"
+                )
+                ?.Nodes()
+            ),
+            Notes = GetDocElements(
+              memberDef
+                .Element("detaileddescription")
+                ?.Descendants("simplesect")
+                .Where(simplesect =>
+                  simplesect.Attribute("kind")?.Value == "note"
+                )
+            ),
+          });
         foreach (var functionDoc in functionDocs)
         {
           yield return functionDoc;
@@ -98,7 +114,8 @@ namespace NvimClient.APIGenerator.Docs
     }
 
     private static IEnumerable<IDocElement> GetDocElements(
-      IEnumerable<XNode> nodes)
+      IEnumerable<XNode> nodes
+    )
     {
       if (nodes == null)
       {
@@ -116,12 +133,16 @@ namespace NvimClient.APIGenerator.Docs
             yield return new Paragraph(GetDocElements(element.Nodes()));
             yield break;
           case XElement element when element.Name == "itemizedlist":
-            yield return new DocList(DocListType.ItemizedList,
-              GetDocElements(element.Elements("listitem")));
+            yield return new DocList(
+              DocListType.ItemizedList,
+              GetDocElements(element.Elements("listitem"))
+            );
             yield break;
           case XElement element when element.Name == "orderedlist":
-            yield return new DocList(DocListType.OrderedList,
-              GetDocElements(element.Elements("listitem")));
+            yield return new DocList(
+              DocListType.OrderedList,
+              GetDocElements(element.Elements("listitem"))
+            );
             yield break;
           case XElement element:
             yield return new Text(element.Value);
@@ -151,10 +172,13 @@ namespace NvimClient.APIGenerator.Docs
           while ((line = streamReader.ReadLine()) != null)
           {
             Console.WriteLine(
-              Regex.Replace(line, @"^(ArrayOf|DictionaryOf)(\(.*?\))",
-                m => m.Groups[1]
-                     + string.Join('_',
-                       Regex.Split(m.Groups[2].Value, @"[^\w]+")))
+              Regex.Replace(
+                line,
+                @"^(ArrayOf|DictionaryOf)(\(.*?\))",
+                m =>
+                  m.Groups[1]
+                  + string.Join('_', Regex.Split(m.Groups[2].Value, @"[^\w]+"))
+              )
             );
           }
         }
@@ -165,16 +189,18 @@ namespace NvimClient.APIGenerator.Docs
     {
       var doxygenConfig = GetDoxygenConfig();
       var inputDirectory = Path.Combine(_nvimSrcDirectory, "src/nvim/api");
-      var process = Process.Start(new ProcessStartInfo("doxygen", "-")
-      {
-        RedirectStandardInput = true
-      });
+      var process = Process.Start(
+        new ProcessStartInfo("doxygen", "-") { RedirectStandardInput = true }
+      );
       using (var processStandardInput = process.StandardInput)
       {
         var assemblyLocation = Assembly.GetExecutingAssembly().Location;
-        processStandardInput.Write(doxygenConfig, _tempOutputDirectory,
+        processStandardInput.Write(
+          doxygenConfig,
+          _tempOutputDirectory,
           inputDirectory,
-          $"dotnet \"{assemblyLocation}\" {DoxygenFilterArgument}");
+          $"dotnet \"{assemblyLocation}\" {DoxygenFilterArgument}"
+        );
       }
 
       process.WaitForExit();
@@ -182,10 +208,13 @@ namespace NvimClient.APIGenerator.Docs
 
     private static string GetDoxygenConfig()
     {
-      const string configName = nameof(NvimClient) + "." + nameof(APIGenerator)
-                                + ".doxygen.config";
-      using (var stream = Assembly.GetExecutingAssembly()
-        .GetManifestResourceStream(configName))
+      const string configName =
+        nameof(NvimClient) + "." + nameof(APIGenerator) + ".doxygen.config";
+      using (
+        var stream = Assembly
+          .GetExecutingAssembly()
+          .GetManifestResourceStream(configName)
+      )
       {
         using (var reader = new StreamReader(stream))
         {

--- a/src/NvimClient.APIGenerator/Docs/Paragraph.cs
+++ b/src/NvimClient.APIGenerator/Docs/Paragraph.cs
@@ -4,8 +4,7 @@ namespace NvimClient.APIGenerator.Docs
 {
   internal class Paragraph : DocElementContainer
   {
-    public Paragraph(IEnumerable<IDocElement> children) : base(children)
-    {
-    }
+    public Paragraph(IEnumerable<IDocElement> children)
+      : base(children) { }
   }
 }

--- a/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
+++ b/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
@@ -25,7 +25,8 @@ namespace NvimClient
     public static NvimAPIMetadata GetAPIMetadata()
     {
       var process = Process.Start(
-        new NvimProcessStartInfo(StartOption.ApiInfo | StartOption.Headless));
+        new NvimProcessStartInfo(StartOption.ApiInfo | StartOption.Headless)
+      );
 
       var context = new SerializationContext();
       context.DictionarySerlaizationOptions.KeyTransformer =
@@ -68,7 +69,8 @@ namespace NvimClient
       File.WriteAllText(outputPath, csharpFormatResult.Code);
     }
 
-    private static string GenerateCSharpClass(NvimAPIMetadata apiMetadata) => @"
+    private static string GenerateCSharpClass(NvimAPIMetadata apiMetadata) =>
+      @"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -81,22 +83,37 @@ namespace NvimClient.API
 {
   public partial class NvimAPI
   {
-" +
-    GenerateNvimUIEvents(
-      apiMetadata.UIEvents.Where(uiEvent => !IsDeprecated(uiEvent))) + @"
-" + GenerateNvimMethods(
-      apiMetadata.Functions.Where(function =>
-        !IsDeprecated(function) && !function.Method),
-      "nvim_", false) + @"
-" + GenerateNvimTypes(apiMetadata) + @"
-" + GenerateNvimUIEventArgs(
-      apiMetadata.UIEvents.Where(uiEvent => !IsDeprecated(uiEvent))) + @"
+"
+      + GenerateNvimUIEvents(
+        apiMetadata.UIEvents.Where(uiEvent => !IsDeprecated(uiEvent))
+      )
+      + @"
+"
+      + GenerateNvimMethods(
+        apiMetadata.Functions.Where(function =>
+          !IsDeprecated(function) && !function.Method
+        ),
+        "nvim_",
+        false
+      )
+      + @"
+"
+      + GenerateNvimTypes(apiMetadata)
+      + @"
+"
+      + GenerateNvimUIEventArgs(
+        apiMetadata.UIEvents.Where(uiEvent => !IsDeprecated(uiEvent))
+      )
+      + @"
     private void CallUIEventHandler(string eventName, object[] args)
     {
       switch (eventName)
       {
-  " + GenerateNvimUIEventCalls(
-        apiMetadata.UIEvents.Where(uiEvent => !IsDeprecated(uiEvent))) + @"
+  "
+      + GenerateNvimUIEventCalls(
+        apiMetadata.UIEvents.Where(uiEvent => !IsDeprecated(uiEvent))
+      )
+      + @"
       }
     }
 
@@ -104,7 +121,9 @@ namespace NvimClient.API
     {
       switch (msgPackExtObj.TypeCode)
       {
-" + GenerateNvimTypeCases(apiMetadata.Types) + @"
+"
+      + GenerateNvimTypeCases(apiMetadata.Types)
+      + @"
         default:
           throw new SerializationException(
             $""Unknown extension type id {msgPackExtObj.TypeCode}"");
@@ -114,12 +133,15 @@ namespace NvimClient.API
 }";
 
     private static string GenerateNvimUIEventCalls(
-      IEnumerable<NvimUIEvent> uiEvents) =>
-      string.Join("", uiEvents.Select(uiEvent =>
-      {
-        var camelCaseName = StringUtil.ConvertToCamelCase(uiEvent.Name, true);
-        var eventArgs = uiEvent.Parameters.Any()
-          ? $@"new {camelCaseName}EventArgs
+      IEnumerable<NvimUIEvent> uiEvents
+    ) =>
+      string.Join(
+        "",
+        uiEvents.Select(uiEvent =>
+        {
+          var camelCaseName = StringUtil.ConvertToCamelCase(uiEvent.Name, true);
+          var eventArgs = uiEvent.Parameters.Any()
+            ? $@"new {camelCaseName}EventArgs
           {{
 {
               string.Join(",\n", uiEvent.Parameters.Select((param, index) =>
@@ -130,17 +152,20 @@ namespace NvimClient.API
               }))
             }
           }}"
-          : "EventArgs.Empty";
-        return $@"
+            : "EventArgs.Empty";
+          return $@"
       case ""{uiEvent.Name}"":
           {camelCaseName}Event?.Invoke(this, {eventArgs});
           break;
 ";
-      }));
+        })
+      );
 
     private static string GenerateNvimUIEvents(
-      IEnumerable<NvimUIEvent> uiEvents) =>
-      string.Join("\n",
+      IEnumerable<NvimUIEvent> uiEvents
+    ) =>
+      string.Join(
+        "\n",
         uiEvents.Select(uiEvent =>
         {
           var camelCaseName = StringUtil.ConvertToCamelCase(uiEvent.Name, true);
@@ -148,15 +173,20 @@ namespace NvimClient.API
             ? $"<{camelCaseName}EventArgs>"
             : string.Empty;
           return $"    public event EventHandler{genericTypeParam} {camelCaseName}Event;";
-        }));
+        })
+      );
 
     private static string GenerateNvimUIEventArgs(
-      IEnumerable<NvimUIEvent> uiEvents) =>
-      string.Join("", uiEvents.Where(uiEvent => uiEvent.Parameters.Any())
-                              .Select(uiEvent =>
-      {
-        var eventName = StringUtil.ConvertToCamelCase(uiEvent.Name, true);
-        return $@"
+      IEnumerable<NvimUIEvent> uiEvents
+    ) =>
+      string.Join(
+        "",
+        uiEvents
+          .Where(uiEvent => uiEvent.Parameters.Any())
+          .Select(uiEvent =>
+          {
+            var eventName = StringUtil.ConvertToCamelCase(uiEvent.Name, true);
+            return $@"
   public class {eventName}EventArgs : EventArgs
   {{
 {
@@ -168,14 +198,17 @@ namespace NvimClient.API
       }))
 }
   }}";
-      }));
+          })
+      );
 
     private static string GenerateNvimTypes(NvimAPIMetadata apiMetadata)
     {
-      return string.Join("", apiMetadata.Types.Select(type =>
-      {
-        var name = "Nvim" + StringUtil.ConvertToCamelCase(type.Key, true);
-        return $@"
+      return string.Join(
+        "",
+        apiMetadata.Types.Select(type =>
+        {
+          var name = "Nvim" + StringUtil.ConvertToCamelCase(type.Key, true);
+          return $@"
   public class {name}
   {{
     private readonly NvimAPI _api;
@@ -193,45 +226,53 @@ namespace NvimClient.API
       type.Value.Prefix, true)
     }
   }}";
-      }));
+        })
+      );
     }
 
     private static string GenerateNvimMethods(
-      IEnumerable<NvimFunction> functions, string prefixToRemove,
-      bool isVirtualMethod) =>
-      string.Join("", functions.Select(function =>
-      {
-        if (!function.Name.StartsWith(prefixToRemove))
+      IEnumerable<NvimFunction> functions,
+      string prefixToRemove,
+      bool isVirtualMethod
+    ) =>
+      string.Join(
+        "",
+        functions.Select(function =>
         {
-          throw new Exception(
-            $"Function {function.Name} does not "
-            + $"have expected prefix \"{prefixToRemove}\"");
-        }
-
-        FunctionDoc doc = null;
-        _functionDocs?.TryGetValue(function.Name, out doc);
-        var camelCaseName =
-          StringUtil.ConvertToCamelCase(
-            function.Name.Substring(prefixToRemove.Length), true);
-        var sendAccess = function.Method ? "_api." : string.Empty;
-        var returnType = NvimTypesMap.GetCSharpType(function.ReturnType);
-        var genericTypeParam =
-          returnType == "void" ? string.Empty : $"<{returnType}>";
-        var parameters =
-          (isVirtualMethod ? function.Parameters.Skip(1) : function.Parameters)
-          .Select(param =>
-          new
+          if (!function.Name.StartsWith(prefixToRemove))
           {
-            param.Type,
-            // Prefix every parameter name with the verbatim identifier `@`
-            // to prevent them from being interpreted as keywords.
-            // In the future, it might be worth considering adding a list
-            // of all C# keywords and only adding the prefix to parameter
-            // names that are in the list.
-            Name = "@" + StringUtil.ConvertToCamelCase(param.Name, false)
-          }).ToArray();
+            throw new Exception(
+              $"Function {function.Name} does not "
+                + $"have expected prefix \"{prefixToRemove}\""
+            );
+          }
 
-        return $@"{string.Join(string.Empty,
+          FunctionDoc doc = null;
+          _functionDocs?.TryGetValue(function.Name, out doc);
+          var camelCaseName = StringUtil.ConvertToCamelCase(
+            function.Name.Substring(prefixToRemove.Length),
+            true
+          );
+          var sendAccess = function.Method ? "_api." : string.Empty;
+          var returnType = NvimTypesMap.GetCSharpType(function.ReturnType);
+          var genericTypeParam =
+            returnType == "void" ? string.Empty : $"<{returnType}>";
+          var parameters = (
+            isVirtualMethod ? function.Parameters.Skip(1) : function.Parameters
+          )
+            .Select(param => new
+            {
+              param.Type,
+              // Prefix every parameter name with the verbatim identifier `@`
+              // to prevent them from being interpreted as keywords.
+              // In the future, it might be worth considering adding a list
+              // of all C# keywords and only adding the prefix to parameter
+              // names that are in the list.
+              Name = "@" + StringUtil.ConvertToCamelCase(param.Name, false),
+            })
+            .ToArray();
+
+          return $@"{string.Join(string.Empty,
           GetDocElement("summary", doc?.Summary).Concat(
             doc?.Parameters
               .Where(param =>
@@ -258,18 +299,23 @@ namespace NvimClient.API
             .Concat(parameters.Select(param => param.Name)))})
       }});
 ";
-      }));
+        })
+      );
 
-    private static IEnumerable<string> GetDocElement(string tag,
-      IEnumerable<IDocElement> elements, string tagAttributes = null)
+    private static IEnumerable<string> GetDocElement(
+      string tag,
+      IEnumerable<IDocElement> elements,
+      string tagAttributes = null
+    )
     {
       if (elements == null)
       {
         yield break;
       }
 
-      using (var lineEnumerator =
-        elements.SelectMany(GetDocLines).GetEnumerator())
+      using (
+        var lineEnumerator = elements.SelectMany(GetDocLines).GetEnumerator()
+      )
       {
         if (!lineEnumerator.MoveNext())
         {
@@ -310,8 +356,7 @@ namespace NvimClient.API
 
           yield break;
         case DocList list:
-          yield return
-            "<list type=\""
+          yield return "<list type=\""
             + (list.ListType == DocListType.ItemizedList ? "bullet" : "number")
             + "\">";
           foreach (var listItemLines in list.Children.Select(GetDocLines))
@@ -339,17 +384,22 @@ namespace NvimClient.API
 
     private static IEnumerable<string> EscapeDocLines(string text) =>
       (SecurityElement.Escape(text) ?? string.Empty)
-      .Replace("\r\n", "\n")
-      .Replace('\r', '\n')
-      .Split('\n');
+        .Replace("\r\n", "\n")
+        .Replace('\r', '\n')
+        .Split('\n');
 
-    private static string
-      GenerateNvimTypeCases(Dictionary<string, NvimType> apiMetadata) =>
-      string.Join(string.Empty, apiMetadata.Select(type => $@"
+    private static string GenerateNvimTypeCases(
+      Dictionary<string, NvimType> apiMetadata
+    ) =>
+      string.Join(
+        string.Empty,
+        apiMetadata.Select(type =>
+          $@"
         case {type.Value.Id}:
           return new Nvim{
             StringUtil.ConvertToCamelCase(type.Key, true)
-            }(this, msgPackExtObj);")
+            }(this, msgPackExtObj);"
+        )
       );
   }
 }

--- a/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
+++ b/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security;
+using CSharpier.Core.CSharp;
 using MsgPack.Serialization;
 using NvimClient.APIGenerator.Docs;
 using NvimClient.NvimMsgpack;
@@ -34,8 +35,10 @@ namespace NvimClient
       return apiMetadata;
     }
 
-    public static void GenerateCSharpFile(string outputPath,
-      IEnumerable<FunctionDoc> functionDocs)
+    public static void GenerateCSharpFile(
+      string outputPath,
+      IEnumerable<FunctionDoc> functionDocs
+    )
     {
       _functionDocs = functionDocs
         .GroupBy(x => x.Function)
@@ -47,10 +50,22 @@ namespace NvimClient
       var apiMetadata = GetAPIMetadata();
 
       // Filter out functions only callable from Lua.
-      apiMetadata.Functions = apiMetadata.Functions.Where(f => !f.Parameters.Where(p => p.Type == "LuaRef").Any()).ToArray();
+      apiMetadata.Functions = apiMetadata
+        .Functions.Where(f =>
+          !f.Parameters.Where(p => p.Type == "LuaRef").Any()
+        )
+        .ToArray();
 
-      var csharpClass = GenerateCSharpClass(apiMetadata);
-      File.WriteAllText(outputPath, csharpClass);
+      var csharpFormatResult = CSharpFormatter
+        .Format(GenerateCSharpClass(apiMetadata))
+        .ToCSharpierResult();
+
+      if (csharpFormatResult.IsExceptional)
+      {
+        throw csharpFormatResult.Exception;
+      }
+
+      File.WriteAllText(outputPath, csharpFormatResult.Code);
     }
 
     private static string GenerateCSharpClass(NvimAPIMetadata apiMetadata) => @"

--- a/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
+++ b/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
@@ -37,8 +37,13 @@ namespace NvimClient
     public static void GenerateCSharpFile(string outputPath,
       IEnumerable<FunctionDoc> functionDocs)
     {
-      _functionDocs = functionDocs?.ToDictionary(functionDoc => functionDoc.Function,
-        funcDoc => funcDoc);
+      _functionDocs = functionDocs
+        .GroupBy(x => x.Function)
+        .ToDictionary(
+          functionDoc => functionDoc.Key,
+          funcDoc => funcDoc.First()
+        );
+
       var apiMetadata = GetAPIMetadata();
 
       // Filter out functions only callable from Lua.

--- a/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
+++ b/src/NvimClient.APIGenerator/NvimAPIGenerator.cs
@@ -288,8 +288,11 @@ namespace NvimClient.API
           yield return "</para>";
           yield break;
         case InlineCode inlineCode:
-          yield return
-            $"<c>${SecurityElement.Escape(inlineCode.ToString())}</c>";
+          foreach (var line in EscapeDocLines(inlineCode.ToString()))
+          {
+            yield return $"<c>{line}</c>";
+          }
+
           yield break;
         case DocList list:
           yield return
@@ -310,10 +313,20 @@ namespace NvimClient.API
           yield return "</list>";
           yield break;
         default:
-          yield return SecurityElement.Escape(element.ToString());
+          foreach (var line in EscapeDocLines(element.ToString()))
+          {
+            yield return line;
+          }
+
           yield break;
       }
     }
+
+    private static IEnumerable<string> EscapeDocLines(string text) =>
+      (SecurityElement.Escape(text) ?? string.Empty)
+      .Replace("\r\n", "\n")
+      .Replace('\r', '\n')
+      .Split('\n');
 
     private static string
       GenerateNvimTypeCases(Dictionary<string, NvimType> apiMetadata) =>

--- a/src/NvimClient.APIGenerator/NvimClient.APIGenerator.csproj
+++ b/src/NvimClient.APIGenerator/NvimClient.APIGenerator.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,5 +10,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NvimClient\NvimClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CSharpier.Core" />
   </ItemGroup>
 </Project>

--- a/src/NvimClient.APIGenerator/Program.cs
+++ b/src/NvimClient.APIGenerator/Program.cs
@@ -14,10 +14,11 @@ namespace NvimClient.APIGenerator
         var projectName = Assembly.GetExecutingAssembly().GetName().Name;
         Console.WriteLine(
           "Generates a C# class file containing wrappers for Neovim API "
-        + "functions and events.\n\n"
-        + $"Usage: dotnet run --project {projectName}.csproj output.cs [nvim src]\n\n"
-        + "output.cs\t\toutput path of the generated C# class file" +
-          "nvim src\t\tpath to the Neovim source directory for generating documentation");
+            + "functions and events.\n\n"
+            + $"Usage: dotnet run --project {projectName}.csproj output.cs [nvim src]\n\n"
+            + "output.cs\t\toutput path of the generated C# class file"
+            + "nvim src\t\tpath to the Neovim source directory for generating documentation"
+        );
         return 1;
       }
 
@@ -29,12 +30,16 @@ namespace NvimClient.APIGenerator
 
       var outputPath = args.First();
       var nvimSrcDirectory = args.ElementAtOrDefault(1);
-      using (var docs = string.IsNullOrEmpty(nvimSrcDirectory)
-        ? null
-        : new DoxygenParser(nvimSrcDirectory))
+      using (
+        var docs = string.IsNullOrEmpty(nvimSrcDirectory)
+          ? null
+          : new DoxygenParser(nvimSrcDirectory)
+      )
       {
-        NvimAPIGenerator.GenerateCSharpFile(outputPath,
-          docs?.GetDocumentation());
+        NvimAPIGenerator.GenerateCSharpFile(
+          outputPath,
+          docs?.GetDocumentation()
+        );
       }
       return 0;
     }

--- a/src/NvimClient/EnumUtil.cs
+++ b/src/NvimClient/EnumUtil.cs
@@ -14,7 +14,8 @@ namespace NvimClient
     /// <returns>
     /// The attribute of type T that exists on the enum value.
     /// </returns>
-    public static T GetAttribute<T>(Enum enumValue) where T : Attribute
+    public static T GetAttribute<T>(Enum enumValue)
+      where T : Attribute
     {
       var type = enumValue.GetType();
       var valueName = Enum.GetName(type, enumValue);

--- a/src/NvimClient/NvimMsgpack/Models/NvimErrorType.cs
+++ b/src/NvimClient/NvimMsgpack/Models/NvimErrorType.cs
@@ -1,6 +1,4 @@
 namespace NvimClient.NvimMsgpack.Models
 {
-  public class NvimErrorType : NvimTypeBase
-  {
-  }
+  public class NvimErrorType : NvimTypeBase { }
 }

--- a/src/NvimClient/NvimMsgpack/Models/NvimNotification.cs
+++ b/src/NvimClient/NvimMsgpack/Models/NvimNotification.cs
@@ -6,7 +6,10 @@ namespace NvimClient.NvimMsgpack.Models
   [NvimMessageType(2)]
   public class NvimNotification : NvimMessage
   {
-    [MessagePackMember(1)] public string Method { get; set; }
-    [MessagePackMember(2)] public MessagePackObject Arguments { get; set; }
+    [MessagePackMember(1)]
+    public string Method { get; set; }
+
+    [MessagePackMember(2)]
+    public MessagePackObject Arguments { get; set; }
   }
 }

--- a/src/NvimClient/NvimMsgpack/Models/NvimParameter.cs
+++ b/src/NvimClient/NvimMsgpack/Models/NvimParameter.cs
@@ -4,7 +4,10 @@ namespace NvimClient.NvimMsgpack.Models
 {
   public class NvimParameter
   {
-    [MessagePackMember(0)] public string Type { get; set; }
-    [MessagePackMember(1)] public string Name { get; set; }
+    [MessagePackMember(0)]
+    public string Type { get; set; }
+
+    [MessagePackMember(1)]
+    public string Name { get; set; }
   }
 }

--- a/src/NvimClient/NvimMsgpack/Models/NvimRequest.cs
+++ b/src/NvimClient/NvimMsgpack/Models/NvimRequest.cs
@@ -6,8 +6,13 @@ namespace NvimClient.NvimMsgpack.Models
   [NvimMessageType(0)]
   public class NvimRequest : NvimMessage
   {
-    [MessagePackMember(1)] public uint MessageId { get; set; }
-    [MessagePackMember(2)] public string Method { get; set; }
-    [MessagePackMember(3)] public MessagePackObject Arguments { get; set; }
+    [MessagePackMember(1)]
+    public uint MessageId { get; set; }
+
+    [MessagePackMember(2)]
+    public string Method { get; set; }
+
+    [MessagePackMember(3)]
+    public MessagePackObject Arguments { get; set; }
   }
 }

--- a/src/NvimClient/NvimMsgpack/Models/NvimResponse.cs
+++ b/src/NvimClient/NvimMsgpack/Models/NvimResponse.cs
@@ -6,8 +6,13 @@ namespace NvimClient.NvimMsgpack.Models
   [NvimMessageType(1)]
   public class NvimResponse : NvimMessage
   {
-    [MessagePackMember(1)] public uint MessageId { get; set; }
-    [MessagePackMember(2)] public MessagePackObject Error { get; set; }
-    [MessagePackMember(3)] public MessagePackObject Result { get; set; }
+    [MessagePackMember(1)]
+    public uint MessageId { get; set; }
+
+    [MessagePackMember(2)]
+    public MessagePackObject Error { get; set; }
+
+    [MessagePackMember(3)]
+    public MessagePackObject Result { get; set; }
   }
 }

--- a/src/NvimClient/NvimMsgpack/Models/NvimUIEvent.cs
+++ b/src/NvimClient/NvimMsgpack/Models/NvimUIEvent.cs
@@ -1,6 +1,4 @@
 namespace NvimClient.NvimMsgpack.Models
 {
-  public class NvimUIEvent : NvimFunctionEventBase
-  {
-  }
+  public class NvimUIEvent : NvimFunctionEventBase { }
 }

--- a/src/NvimClient/NvimMsgpack/NvimMessageSerializer.cs
+++ b/src/NvimClient/NvimMsgpack/NvimMessageSerializer.cs
@@ -18,25 +18,28 @@ namespace NvimClient.NvimMsgpack
       long GetTypeId(Type type)
       {
         var attribute = type.GetCustomAttribute<NvimMessageTypeAttribute>();
-        return attribute?.Id ??
-               throw new TypeLoadException(
-                 $"{type} does not have {nameof(NvimMessageTypeAttribute)}");
+        return attribute?.Id
+          ?? throw new TypeLoadException(
+            $"{type} does not have {nameof(NvimMessageTypeAttribute)}"
+          );
       }
 
       var baseType = typeof(NvimMessage);
-      NvimMessageTypes = baseType.Assembly.GetTypes()
-                                 .Where(type => type.IsSubclassOf(baseType))
-                                 .ToDictionary(GetTypeId);
+      NvimMessageTypes = baseType
+        .Assembly.GetTypes()
+        .Where(type => type.IsSubclassOf(baseType))
+        .ToDictionary(GetTypeId);
     }
 
-    public NvimMessageSerializer(SerializationContext ctx) : base(ctx)
-    {
-    }
+    public NvimMessageSerializer(SerializationContext ctx)
+      : base(ctx) { }
 
     protected override void PackToCore(Packer packer, NvimMessage message)
     {
-      message.TypeId = message.GetType()
-        .GetCustomAttribute<NvimMessageTypeAttribute>().Id;
+      message.TypeId = message
+        .GetType()
+        .GetCustomAttribute<NvimMessageTypeAttribute>()
+        .Id;
 
       packer.PackObject(message);
       packer.Flush();
@@ -53,11 +56,15 @@ namespace NvimClient.NvimMsgpack
       var messageTypeId = messagePackObject.AsEnumerable().First().AsInt64();
       if (!NvimMessageTypes.TryGetValue(messageTypeId, out var messageType))
       {
-        throw new SerializationException($"Unknown message type (id {messageTypeId})");
+        throw new SerializationException(
+          $"Unknown message type (id {messageTypeId})"
+        );
       }
 
-      return (NvimMessage)OwnerContext.GetSerializer(messageType)
-        .FromMessagePackObject(messagePackObject);
+      return (NvimMessage)
+        OwnerContext
+          .GetSerializer(messageType)
+          .FromMessagePackObject(messagePackObject);
     }
   }
 }

--- a/src/NvimClient/NvimMsgpack/NvimMessageTypeAttribute.cs
+++ b/src/NvimClient/NvimMsgpack/NvimMessageTypeAttribute.cs
@@ -6,6 +6,7 @@ namespace NvimClient.NvimMsgpack
   internal class NvimMessageTypeAttribute : Attribute
   {
     public NvimMessageTypeAttribute(byte id) => Id = id;
+
     public byte Id { get; }
   }
 }

--- a/src/NvimClient/NvimMsgpack/NvimTypesMap.cs
+++ b/src/NvimClient/NvimMsgpack/NvimTypesMap.cs
@@ -8,25 +8,32 @@ namespace NvimClient.NvimMsgpack
 {
   public static class NvimTypesMap
   {
-    private static readonly
-      (string NvimTypeName, string CSharpTypeName, Type CSharpType)[] _types =
-      {
-        ("Array",           "object[]",            typeof(object[])),
-        ("Boolean",         "bool",                typeof(bool)),
-        ("Dict",            "IDictionary",         typeof(IDictionary)),
-        ("Dictionary",      "IDictionary",         typeof(IDictionary)),
-        ("Float",           "double",              typeof(double)),
-        ("Integer",         "long",                typeof(long)),
-        ("Object",          "object",              typeof(object)),
-        ("String",          "string",              typeof(string)),
-        ("void",            "void",                typeof(void))
-      };
+    private static readonly (
+      string NvimTypeName,
+      string CSharpTypeName,
+      Type CSharpType
+    )[] _types =
+    {
+      ("Array", "object[]", typeof(object[])),
+      ("Boolean", "bool", typeof(bool)),
+      ("Dict", "IDictionary", typeof(IDictionary)),
+      ("Dictionary", "IDictionary", typeof(IDictionary)),
+      ("Float", "double", typeof(double)),
+      ("Integer", "long", typeof(long)),
+      ("Object", "object", typeof(object)),
+      ("String", "string", typeof(string)),
+      ("void", "void", typeof(void)),
+    };
 
     private static Dictionary<string, string> _nvimTypesMap =>
-      _types.ToDictionary(type => type.NvimTypeName, type => type.CSharpTypeName);
+      _types.ToDictionary(
+        type => type.NvimTypeName,
+        type => type.CSharpTypeName
+      );
 
-    private static readonly HashSet<Type> _validCSharpTypes =
-      new HashSet<Type>(_types.Select(type => type.CSharpType));
+    private static readonly HashSet<Type> _validCSharpTypes = new HashSet<Type>(
+      _types.Select(type => type.CSharpType)
+    );
 
     public static string GetCSharpType(string nvimType)
     {
@@ -35,34 +42,41 @@ namespace NvimClient.NvimMsgpack
         return csharpType;
       }
 
-      var arrayRegexMatch = Regex.Match(nvimType,
-        @"^ArrayOf\((?:(?<ElementType>.+), (?<Size>\d+)|(?<ElementType>.+))\)$");
+      var arrayRegexMatch = Regex.Match(
+        nvimType,
+        @"^ArrayOf\((?:(?<ElementType>.+), (?<Size>\d+)|(?<ElementType>.+))\)$"
+      );
       if (arrayRegexMatch.Success)
       {
         var elementType = arrayRegexMatch.Groups["ElementType"].Value;
         return GetCSharpType(elementType) + "[]";
       }
 
-      var dictionaryRegexMatch = Regex.Match(nvimType,
-        @"^DictionaryOf\((?<KeyType>.+), (?<ValueType>.+)?\)$");
+      var dictionaryRegexMatch = Regex.Match(
+        nvimType,
+        @"^DictionaryOf\((?<KeyType>.+), (?<ValueType>.+)?\)$"
+      );
       if (dictionaryRegexMatch.Success)
       {
-        var keyType =
-          GetCSharpType(dictionaryRegexMatch.Groups["KeyType"].Value);
-        var valueType =
-          GetCSharpType(dictionaryRegexMatch.Groups["ValueType"].Value);
+        var keyType = GetCSharpType(
+          dictionaryRegexMatch.Groups["KeyType"].Value
+        );
+        var valueType = GetCSharpType(
+          dictionaryRegexMatch.Groups["ValueType"].Value
+        );
         return $"IDictionary<{keyType}, {valueType}>";
       }
 
-      var dictOfRegexMatch = Regex.Match(nvimType,
-        @"^DictOf\((?<ValueType>.+)\)$");
+      var dictOfRegexMatch = Regex.Match(
+        nvimType,
+        @"^DictOf\((?<ValueType>.+)\)$"
+      );
       if (dictOfRegexMatch.Success)
       {
         return "IDictionary";
       }
 
-      var keyDictRegexMatch = Regex.Match(nvimType,
-        @"^Dict(?:As)?\(.+\)$");
+      var keyDictRegexMatch = Regex.Match(nvimType, @"^Dict(?:As)?\(.+\)$");
       if (keyDictRegexMatch.Success)
       {
         return "IDictionary";
@@ -75,7 +89,7 @@ namespace NvimClient.NvimMsgpack
       _validCSharpTypes.Contains(type)
       || type.IsArray && IsValidType(type.GetElementType())
       || type.IsGenericType
-      && type.GetGenericTypeDefinition() == typeof(IDictionary<,>)
-      && type.GetGenericArguments().All(IsValidType);
+        && type.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+        && type.GetGenericArguments().All(IsValidType);
   }
 }

--- a/src/NvimClient/NvimMsgpack/NvimTypesMap.cs
+++ b/src/NvimClient/NvimMsgpack/NvimTypesMap.cs
@@ -13,6 +13,7 @@ namespace NvimClient.NvimMsgpack
       {
         ("Array",           "object[]",            typeof(object[])),
         ("Boolean",         "bool",                typeof(bool)),
+        ("Dict",            "IDictionary",         typeof(IDictionary)),
         ("Dictionary",      "IDictionary",         typeof(IDictionary)),
         ("Float",           "double",              typeof(double)),
         ("Integer",         "long",                typeof(long)),
@@ -51,6 +52,20 @@ namespace NvimClient.NvimMsgpack
         var valueType =
           GetCSharpType(dictionaryRegexMatch.Groups["ValueType"].Value);
         return $"IDictionary<{keyType}, {valueType}>";
+      }
+
+      var dictOfRegexMatch = Regex.Match(nvimType,
+        @"^DictOf\((?<ValueType>.+)\)$");
+      if (dictOfRegexMatch.Success)
+      {
+        return "IDictionary";
+      }
+
+      var keyDictRegexMatch = Regex.Match(nvimType,
+        @"^Dict(?:As)?\(.+\)$");
+      if (keyDictRegexMatch.Success)
+      {
+        return "IDictionary";
       }
 
       return "Nvim" + nvimType;

--- a/src/NvimClient/NvimProcess/NvimProcess.cs
+++ b/src/NvimClient/NvimProcess/NvimProcess.cs
@@ -28,8 +28,9 @@ namespace NvimClient.NvimProcess
     /// </param>
     /// <returns></returns>
     public static Process Start(
-      string nvimPath, string arguments,
-      StartOption startOptions = StartOption.None) => Start(
-      new NvimProcessStartInfo(nvimPath, arguments, startOptions));
+      string nvimPath,
+      string arguments,
+      StartOption startOptions = StartOption.None
+    ) => Start(new NvimProcessStartInfo(nvimPath, arguments, startOptions));
   }
 }

--- a/src/NvimClient/NvimProcess/NvimProcessStartInfo.cs
+++ b/src/NvimClient/NvimProcess/NvimProcessStartInfo.cs
@@ -16,10 +16,8 @@ namespace NvimClient.NvimProcess
     ///   the specified start options.
     /// </summary>
     /// <param name="startOptions">The options for starting Nvim.</param>
-    public NvimProcessStartInfo(StartOption startOptions) : this(null, null,
-      startOptions)
-    {
-    }
+    public NvimProcessStartInfo(StartOption startOptions)
+      : this(null, null, startOptions) { }
 
     /// <summary>
     ///   Initializes a new instance of the NvimProcessStartInfo class that
@@ -31,11 +29,12 @@ namespace NvimClient.NvimProcess
     /// </param>
     /// <param name="arguments">The arguments to pass to Nvim.</param>
     /// <param name="startOptions">The options for starting Nvim.</param>
-    public NvimProcessStartInfo(string nvimPath, string arguments,
-      StartOption startOptions = StartOption.None) : this(
-      GetProcessStartInfo(nvimPath, arguments, startOptions))
-    {
-    }
+    public NvimProcessStartInfo(
+      string nvimPath,
+      string arguments,
+      StartOption startOptions = StartOption.None
+    )
+      : this(GetProcessStartInfo(nvimPath, arguments, startOptions)) { }
 
     /// <summary>
     ///   Initializes a new instance of the NvimProcessStartInfo class with
@@ -68,37 +67,53 @@ namespace NvimClient.NvimProcess
     }
 
     public static implicit operator NvimProcessStartInfo(
-      ProcessStartInfo startInfo) => new NvimProcessStartInfo(startInfo);
+      ProcessStartInfo startInfo
+    ) => new NvimProcessStartInfo(startInfo);
 
     public static implicit operator ProcessStartInfo(
-      NvimProcessStartInfo startInfo) => startInfo.ProcessStartInfo;
+      NvimProcessStartInfo startInfo
+    ) => startInfo.ProcessStartInfo;
 
-    private static ProcessStartInfo GetProcessStartInfo(string nvimPath,
-      string arguments, StartOption startOptions = StartOption.None)
+    private static ProcessStartInfo GetProcessStartInfo(
+      string nvimPath,
+      string arguments,
+      StartOption startOptions = StartOption.None
+    )
     {
-      var redirectStandardIO = startOptions.HasFlag(StartOption.ApiInfo) ||
-                               startOptions.HasFlag(StartOption.Embed);
+      var redirectStandardIO =
+        startOptions.HasFlag(StartOption.ApiInfo)
+        || startOptions.HasFlag(StartOption.Embed);
       return new ProcessStartInfo(
-        nvimPath, string.Join(" ",
-          GetFlagsForOptions(startOptions).Append(arguments)
-            .Where(argument => !string.IsNullOrEmpty(argument))))
+        nvimPath,
+        string.Join(
+          " ",
+          GetFlagsForOptions(startOptions)
+            .Append(arguments)
+            .Where(argument => !string.IsNullOrEmpty(argument))
+        )
+      )
       {
-        CreateNoWindow = startOptions.HasFlag(StartOption.Headless) ||
-                         startOptions.HasFlag(StartOption.Embed),
+        CreateNoWindow =
+          startOptions.HasFlag(StartOption.Headless)
+          || startOptions.HasFlag(StartOption.Embed),
         RedirectStandardInput = redirectStandardIO,
         RedirectStandardOutput = redirectStandardIO,
-        RedirectStandardError = redirectStandardIO
+        RedirectStandardError = redirectStandardIO,
       };
     }
 
-    private static IEnumerable<string>
-      GetFlagsForOptions(StartOption startOptions)
+    private static IEnumerable<string> GetFlagsForOptions(
+      StartOption startOptions
+    )
     {
-      return Enum.GetValues(typeof(StartOption)).Cast<StartOption>()
+      return Enum.GetValues(typeof(StartOption))
+        .Cast<StartOption>()
         .Where(option =>
-          option != StartOption.None && startOptions.HasFlag(option))
+          option != StartOption.None && startOptions.HasFlag(option)
+        )
         .Select(option =>
-          EnumUtil.GetAttribute<ArgumentAttribute>(option).Flag);
+          EnumUtil.GetAttribute<ArgumentAttribute>(option).Flag
+        );
     }
   }
 }

--- a/src/NvimClient/NvimProcess/StartOption.cs
+++ b/src/NvimClient/NvimProcess/StartOption.cs
@@ -6,8 +6,14 @@ namespace NvimClient.NvimProcess
   public enum StartOption
   {
     None = 0,
-    [Argument("--embed")] Embed = 1,
-    [Argument("--headless")] Headless = 2,
-    [Argument("--api-info")] ApiInfo = 4
+
+    [Argument("--embed")]
+    Embed = 1,
+
+    [Argument("--headless")]
+    Headless = 2,
+
+    [Argument("--api-info")]
+    ApiInfo = 4,
   }
 }

--- a/src/NvimClient/StringUtil.cs
+++ b/src/NvimClient/StringUtil.cs
@@ -63,8 +63,10 @@ namespace NvimClient
           stringBuilder.Append(char.ToLower(previousChar));
         }
 
-        AppendWithUnderscores(enumerator.Current,
-          currentCharUpper && previousCharUpper);
+        AppendWithUnderscores(
+          enumerator.Current,
+          currentCharUpper && previousCharUpper
+        );
       }
 
       return stringBuilder.ToString();
@@ -77,8 +79,10 @@ namespace NvimClient
     /// <param name="capitalizeFirstChar">
     /// Whether or not the first character should be capitalized.
     /// </param>
-    public static string ConvertToCamelCase(string str,
-      bool capitalizeFirstChar)
+    public static string ConvertToCamelCase(
+      string str,
+      bool capitalizeFirstChar
+    )
     {
       if (string.IsNullOrEmpty(str))
       {
@@ -101,9 +105,11 @@ namespace NvimClient
         var isUnderscore = currentChar == '_';
         if (!isUnderscore)
         {
-          stringBuilder.Append(capitalizeFirstChar
-            ? char.ToUpper(currentChar)
-            : char.ToLower(currentChar));
+          stringBuilder.Append(
+            capitalizeFirstChar
+              ? char.ToUpper(currentChar)
+              : char.ToLower(currentChar)
+          );
           return;
         }
 
@@ -123,9 +129,11 @@ namespace NvimClient
         var isUnderscore = currentChar == '_';
         if (!isUnderscore)
         {
-          stringBuilder.Append(previousUnderscore
-            ? char.ToUpper(currentChar)
-            : char.ToLower(currentChar));
+          stringBuilder.Append(
+            previousUnderscore
+              ? char.ToUpper(currentChar)
+              : char.ToLower(currentChar)
+          );
         }
 
         AppendWithUpperChars(isUnderscore);

--- a/src/NvimPluginHost/AssemblyResolver.cs
+++ b/src/NvimPluginHost/AssemblyResolver.cs
@@ -19,17 +19,17 @@ namespace NvimPluginHost
 
     public AssemblyResolver(string path)
     {
-      Assembly =
-        AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+      Assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
       _dependencyContext = DependencyContext.Load(Assembly);
 
-      _assemblyResolver = new CompositeCompilationAssemblyResolver
-      (new ICompilationAssemblyResolver[]
-       {
-         new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(path)),
-         new ReferenceAssemblyPathResolver(),
-         new PackageCompilationAssemblyResolver()
-       });
+      _assemblyResolver = new CompositeCompilationAssemblyResolver(
+        new ICompilationAssemblyResolver[]
+        {
+          new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(path)),
+          new ReferenceAssemblyPathResolver(),
+          new PackageCompilationAssemblyResolver(),
+        }
+      );
 
       _loadContext = AssemblyLoadContext.GetLoadContext(Assembly);
       _loadContext.Resolving += OnResolving;
@@ -46,12 +46,16 @@ namespace NvimPluginHost
     {
       bool NamesMatch(RuntimeLibrary runtime)
       {
-        return string.Equals(runtime.Name, name.Name,
-          StringComparison.OrdinalIgnoreCase);
+        return string.Equals(
+          runtime.Name,
+          name.Name,
+          StringComparison.OrdinalIgnoreCase
+        );
       }
 
-      var library =
-        _dependencyContext.RuntimeLibraries.FirstOrDefault(NamesMatch);
+      var library = _dependencyContext.RuntimeLibraries.FirstOrDefault(
+        NamesMatch
+      );
       if (library != null)
       {
         var wrapper = new CompilationLibrary(
@@ -61,7 +65,8 @@ namespace NvimPluginHost
           library.Hash,
           library.RuntimeAssemblyGroups.SelectMany(g => g.AssetPaths),
           library.Dependencies,
-          library.Serviceable);
+          library.Serviceable
+        );
 
         var assemblies = new List<string>();
         _assemblyResolver.TryResolveAssemblyPaths(wrapper, assemblies);

--- a/src/NvimPluginHost/Log.cs
+++ b/src/NvimPluginHost/Log.cs
@@ -17,6 +17,7 @@ namespace NvimPluginHost
     }
 
     public static void WriteLine(string text) => _writer?.WriteLine(text);
+
     public static void Write(string text) => _writer?.Write(text);
   }
 }

--- a/src/NvimPluginHost/Program.cs
+++ b/src/NvimPluginHost/Program.cs
@@ -17,8 +17,10 @@ namespace NvimPluginHost
     {
       Log.WriteLine("Plugin host started");
 
-      var nvim = new NvimAPI(Console.OpenStandardOutput(),
-        Console.OpenStandardInput());
+      var nvim = new NvimAPI(
+        Console.OpenStandardOutput(),
+        Console.OpenStandardInput()
+      );
       nvim.OnUnhandledRequest += (sender, request) =>
       {
         // Load the plugin and get the handler asynchronously
@@ -58,36 +60,44 @@ namespace NvimPluginHost
       };
 
       nvim.RegisterHandler("poll", args => "ok");
-      nvim.RegisterHandler("specs", args =>
-      {
-        var slnFilePath = (string)args.First();
-        var pluginType = GetPluginFromSolutionPath(slnFilePath);
-        return pluginType == null
-          ? null
-          : PluginHost.GetPluginSpecs(pluginType);
-      });
+      nvim.RegisterHandler(
+        "specs",
+        args =>
+        {
+          var slnFilePath = (string)args.First();
+          var pluginType = GetPluginFromSolutionPath(slnFilePath);
+          return pluginType == null
+            ? null
+            : PluginHost.GetPluginSpecs(pluginType);
+        }
+      );
 
       nvim.WaitForDisconnect();
 
       Log.WriteLine("Plugin host stopping");
     }
 
-    private static Func<object[], object> GetPluginHandler(NvimAPI nvim,
-      string methodName)
+    private static Func<object[], object> GetPluginHandler(
+      NvimAPI nvim,
+      string methodName
+    )
     {
       var methodNameSplit = methodName.Split(':');
       // On Windows absolute paths contain a colon after
       // the drive letter, so the first two elements must
       // be joined together to obtain the file path.
-      var slnFilePath =
-        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-          ? $"{methodNameSplit[0]}:{methodNameSplit[1]}"
-          : methodNameSplit[0];
+      var slnFilePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? $"{methodNameSplit[0]}:{methodNameSplit[1]}"
+        : methodNameSplit[0];
       var pluginType = GetPluginFromSolutionPath(slnFilePath);
-      var exports =
-        PluginHost.RegisterPluginExports(nvim, slnFilePath, pluginType);
-      return exports.FirstOrDefault(export =>
-        export.HandlerName == methodName)?.Handler;
+      var exports = PluginHost.RegisterPluginExports(
+        nvim,
+        slnFilePath,
+        pluginType
+      );
+      return exports
+        .FirstOrDefault(export => export.HandlerName == methodName)
+        ?.Handler;
     }
 
     private static Type GetPluginFromSolutionPath(string slnFilePath)
@@ -103,11 +113,12 @@ namespace NvimPluginHost
           CreateNoWindow = true,
           RedirectStandardError = true,
           RedirectStandardOutput = true,
-        });
+        }
+      );
       buildProcess?.WaitForExit();
 
-      var plugin = slnFileInfo.Directory.EnumerateFiles(
-          "*.dll", SearchOption.AllDirectories)
+      var plugin = slnFileInfo
+        .Directory.EnumerateFiles("*.dll", SearchOption.AllDirectories)
         .SelectMany(dll =>
         {
           try

--- a/test/NvimClient.Test/NvimClient.Test.csproj
+++ b/test/NvimClient.Test/NvimClient.Test.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -14,5 +13,4 @@
     <ProjectReference Include="..\..\src\NvimClient.API\NvimClient.API.csproj" />
     <ProjectReference Include="..\..\src\NvimClient\NvimClient.csproj" />
   </ItemGroup>
-
 </Project>

--- a/test/NvimClient.Test/NvimTests.cs
+++ b/test/NvimClient.Test/NvimTests.cs
@@ -21,15 +21,18 @@ namespace NvimClient.Test
     [TestMethod]
     public void TestProcessStarts()
     {
-      var process = NvimProcess.NvimProcess.Start(new ProcessStartInfo
-      {
-        Arguments = "--version",
-        RedirectStandardOutput = true
-      });
+      var process = NvimProcess.NvimProcess.Start(
+        new ProcessStartInfo
+        {
+          Arguments = "--version",
+          RedirectStandardOutput = true,
+        }
+      );
       process.WaitForExit();
       Assert.IsTrue(
-        process.StandardOutput.ReadToEnd().Contains("NVIM") &&
-        process.ExitCode == 0);
+        process.StandardOutput.ReadToEnd().Contains("NVIM")
+          && process.ExitCode == 0
+      );
     }
 
     [DataTestMethod]
@@ -47,7 +50,8 @@ namespace NvimClient.Test
     public void TestApiMetadataDeserialization()
     {
       var process = Process.Start(
-        new NvimProcessStartInfo(StartOption.ApiInfo | StartOption.Headless));
+        new NvimProcessStartInfo(StartOption.ApiInfo | StartOption.Headless)
+      );
 
       var context = new SerializationContext();
       context.DictionarySerlaizationOptions.KeyTransformer =
@@ -56,17 +60,20 @@ namespace NvimClient.Test
       var apiMetadata = serializer.Unpack(process.StandardOutput.BaseStream);
 
       Assert.IsNotNull(apiMetadata.Version);
-      Assert.IsTrue(apiMetadata.Functions.Any()
-                    && apiMetadata.UIEvents.Any()
-                    && apiMetadata.Types.Any()
-                    && apiMetadata.ErrorTypes.Any());
+      Assert.IsTrue(
+        apiMetadata.Functions.Any()
+          && apiMetadata.UIEvents.Any()
+          && apiMetadata.Types.Any()
+          && apiMetadata.ErrorTypes.Any()
+      );
     }
 
     [TestMethod]
     public void TestMessageDeserialization()
     {
       var process = Process.Start(
-        new NvimProcessStartInfo(StartOption.Embed | StartOption.Headless));
+        new NvimProcessStartInfo(StartOption.Embed | StartOption.Headless)
+      );
 
       var context = new SerializationContext();
       context.Serializers.Register(new NvimMessageSerializer(context));
@@ -77,15 +84,20 @@ namespace NvimClient.Test
       {
         MessageId = 42,
         Method = "nvim_eval",
-        Arguments = new MessagePackObject(new MessagePackObject[] { $"'{testString}'" })
+        Arguments = new MessagePackObject(
+          new MessagePackObject[] { $"'{testString}'" }
+        ),
       };
       serializer.Pack(process.StandardInput.BaseStream, request);
 
-      var response = (NvimResponse)serializer.Unpack(process.StandardOutput.BaseStream);
+      var response = (NvimResponse)
+        serializer.Unpack(process.StandardOutput.BaseStream);
 
-      Assert.IsTrue(response.MessageId == request.MessageId
-                    && response.Error == MessagePackObject.Nil
-                    && response.Result == testString);
+      Assert.IsTrue(
+        response.MessageId == request.MessageId
+          && response.Error == MessagePackObject.Nil
+          && response.Result == testString
+      );
     }
 
     [DataTestMethod]
@@ -97,11 +109,16 @@ namespace NvimClient.Test
     [DataRow("aa_aa", "aaAa", false)]
     [DataRow("aaa_a", "AaaA", true)]
     [DataRow("aaa_a", "aaaA", false)]
-    public void TestConvertToCamelCase(string input, string expected,
-      bool capitalizeFirstChar)
+    public void TestConvertToCamelCase(
+      string input,
+      string expected,
+      bool capitalizeFirstChar
+    )
     {
-      Assert.AreEqual(expected,
-        StringUtil.ConvertToCamelCase(input, capitalizeFirstChar));
+      Assert.AreEqual(
+        expected,
+        StringUtil.ConvertToCamelCase(input, capitalizeFirstChar)
+      );
     }
 
     [TestMethod]
@@ -116,15 +133,19 @@ namespace NvimClient.Test
     public async Task TestCallAndReply()
     {
       var api = new NvimAPI();
-      api.RegisterHandler("client-call", args =>
-      {
-        CollectionAssert.AreEqual(new[] { 1L, 2L, 3L }, args);
-        return new[] { 4, 5, 6 };
-      });
+      api.RegisterHandler(
+        "client-call",
+        args =>
+        {
+          CollectionAssert.AreEqual(new[] { 1L, 2L, 3L }, args);
+          return new[] { 4, 5, 6 };
+        }
+      );
       var objects = await api.GetApiInfo();
       var channelID = (long)objects.First();
       await api.Command(
-        $"let g:result = rpcrequest({channelID}, 'client-call', 1, 2, 3)");
+        $"let g:result = rpcrequest({channelID}, 'client-call', 1, 2, 3)"
+      );
       var result = (object[])await api.GetVar("result");
       CollectionAssert.AreEqual(new[] { 4L, 5L, 6L }, result);
     }
@@ -135,7 +156,8 @@ namespace NvimClient.Test
     {
       const string testString = "hello_world";
       var titleSetTask = new TaskCompletionSource<bool>(
-        TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCreationOptions.RunContinuationsAsynchronously
+      );
       var api = new NvimAPI();
       api.SetTitleEvent += (sender, args) =>
       {
@@ -146,13 +168,22 @@ namespace NvimClient.Test
       };
       var objects = await api.GetApiInfo();
       var channelID = (long)objects.First();
-      var serverAddress = (string)await api.CallFunction("serverstart",
-        new object[] { System.Net.IPAddress.Loopback + ":" });
+      var serverAddress = (string)
+        await api.CallFunction(
+          "serverstart",
+          new object[] { System.Net.IPAddress.Loopback + ":" }
+        );
       var sender = new NvimAPI(serverAddress);
       await sender.Command(
-        $"call rpcnotify({channelID}, 'redraw', ['set_title', ['{testString}']])");
-      Assert.AreEqual(titleSetTask.Task,
-        await Task.WhenAny(titleSetTask.Task, Task.Delay(TimeSpan.FromSeconds(5))));
+        $"call rpcnotify({channelID}, 'redraw', ['set_title', ['{testString}']])"
+      );
+      Assert.AreEqual(
+        titleSetTask.Task,
+        await Task.WhenAny(
+          titleSetTask.Task,
+          Task.Delay(TimeSpan.FromSeconds(5))
+        )
+      );
       Assert.IsTrue(await titleSetTask.Task);
     }
 
@@ -165,12 +196,16 @@ namespace NvimClient.Test
       await PluginHost.RegisterPlugin<TestPlugin>(api, pluginPath);
 
       await api.Command(
-        $"let g:result = {nameof(TestPlugin.AddNumbers)}(1, 2)");
+        $"let g:result = {nameof(TestPlugin.AddNumbers)}(1, 2)"
+      );
       var result = await api.GetVar("result");
       Assert.AreEqual(3L, result);
 
       await api.Command($"{nameof(TestPlugin.TestCommand1)} a b c");
-      CollectionAssert.AreEqual(new[] { "a", "b", "c" }, TestPlugin.Command1Args);
+      CollectionAssert.AreEqual(
+        new[] { "a", "b", "c" },
+        TestPlugin.Command1Args
+      );
 
       await api.Command($"{nameof(TestPlugin.TestCommand2)} 1 2 3");
       Assert.AreEqual("1 2 3", TestPlugin.Command2Args);
@@ -186,8 +221,11 @@ namespace NvimClient.Test
     public async Task TestTCPSocket()
     {
       var nvimStdio = new NvimAPI();
-      var serverAddress = (string)await nvimStdio.CallFunction("serverstart",
-        new object[] { System.Net.IPAddress.Loopback + ":" });
+      var serverAddress = (string)
+        await nvimStdio.CallFunction(
+          "serverstart",
+          new object[] { System.Net.IPAddress.Loopback + ":" }
+        );
 
       var nvimTCPSocket = new NvimAPI(serverAddress);
       Assert.IsNotNull(await nvimTCPSocket.CommandOutput("version"));
@@ -197,8 +235,8 @@ namespace NvimClient.Test
     public async Task TestLocalSocket()
     {
       var nvimStdio = new NvimAPI();
-      var serverAddress =
-        (string)await nvimStdio.CallFunction("serverstart", new object[0]);
+      var serverAddress = (string)
+        await nvimStdio.CallFunction("serverstart", new object[0]);
 
       var nvimLocalSocket = new NvimAPI(serverAddress);
       Assert.IsNotNull(await nvimLocalSocket.CommandOutput("version"));
@@ -235,8 +273,14 @@ namespace NvimClient.Test
     [DataRow("ArrayOf(Float)", "double[]")]
     [DataRow("ArrayOf(Integer, 2)", "long[]")]
     [DataRow("ArrayOf(Buffer)", "NvimBuffer[]")]
-    [DataRow("ArrayOf(DictionaryOf(String, String))", "IDictionary<string, string>[]")]
-    [DataRow("DictionaryOf(Integer, ArrayOf(String))", "IDictionary<long, string[]>")]
+    [DataRow(
+      "ArrayOf(DictionaryOf(String, String))",
+      "IDictionary<string, string>[]"
+    )]
+    [DataRow(
+      "DictionaryOf(Integer, ArrayOf(String))",
+      "IDictionary<long, string[]>"
+    )]
     public void TestCSharpTypeConversion(string nvimType, string csharpType)
     {
       Assert.AreEqual(csharpType, NvimTypesMap.GetCSharpType(nvimType));

--- a/test/NvimClient.Test/NvimTests.cs
+++ b/test/NvimClient.Test/NvimTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -213,6 +214,7 @@ namespace NvimClient.Test
     [DataRow(typeof(object[]), true)]
     [DataRow(typeof(long[]), true)]
     [DataRow(typeof(int[]), false)]
+    [DataRow(typeof(IDictionary), true)]
     [DataRow(typeof(IDictionary<object, object>), true)]
     [DataRow(typeof(IDictionary<long, string>), true)]
     [DataRow(typeof(IDictionary<string, DateTime>), false)]
@@ -225,6 +227,10 @@ namespace NvimClient.Test
     [DataTestMethod]
     [DataRow("Boolean", "bool")]
     [DataRow("Array", "object[]")]
+    [DataRow("Dict", "IDictionary")]
+    [DataRow("DictAs(get_mode)", "IDictionary")]
+    [DataRow("DictOf(Integer)", "IDictionary")]
+    [DataRow("Dict(win_config)", "IDictionary")]
     [DataRow("Dictionary", "IDictionary")]
     [DataRow("ArrayOf(Float)", "double[]")]
     [DataRow("ArrayOf(Integer, 2)", "long[]")]

--- a/test/NvimClient.Test/TestPlugin.cs
+++ b/test/NvimClient.Test/TestPlugin.cs
@@ -39,8 +39,10 @@ namespace NvimClient.Test
     }
 
     [NvimAutocmd("BufEnter", Pattern = "*.cs")]
-    public void OnBufEnter([NvimEval("expand('<afile>')")] string filename,
-      [NvimEval("&shiftwidth")] long shiftWidth)
+    public void OnBufEnter(
+      [NvimEval("expand('<afile>')")] string filename,
+      [NvimEval("&shiftwidth")] long shiftWidth
+    )
     {
       AutocmdCalled = true;
     }


### PR DESCRIPTION
Adds CSharpier formatting for generated and hand-written C# code, with CI coverage for format checks.

Commits in order add the CI job and the csharpier application to the generated client before the large format changes.

## Blocked by

- #25 
- #32

Closes #27 