### PR TITLE
fix: cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,53 +18,66 @@ Quickstart for Linux
    dotnet test test/NvimClient.Test/NvimClient.Test.csproj
    ```
 
-Neovim RPC module
------------------
+Plugin Example
+--------------
 
-Install the `NvimClient.API` package in an executable project. Its standard
-output is the MessagePack RPC stream: write diagnostics only to standard error.
+The following is a complete, working RPC module. It adds an `:ExampleAdd`
+command that prints `3`.
 
-```csharp
-using System;
-using NvimClient.API;
+1. From the repository root, create a console project and reference
+   `NvimClient.API`:
+   ```sh
+   dotnet new console --output NvimNetExample
+   dotnet add NvimNetExample/NvimNetExample.csproj reference src/NvimClient.API/NvimClient.API.csproj
+   cd NvimNetExample
+   ```
+2. Replace `Program.cs` with:
+   ```csharp
+   using System;
+   using NvimClient.API;
 
-internal static class Program
-{
-  private static void Main()
-  {
-    var nvim = NvimAPI.CreateFromStandardIO();
-    nvim.RegisterHandler(
-      "example.add",
-      args => (long)args[0] + (long)args[1]
-    );
-    nvim.RegisterHandler(
-      "example.buf-enter",
-      args => Console.Error.WriteLine($"Opened {args[0]}")
-    );
-    nvim.WaitForDisconnect();
-  }
-}
-```
+   var nvim = NvimAPI.CreateFromStandardIO();
+   nvim.RegisterHandler(
+     "example.add",
+     args => (long)args[0] + (long)args[1]
+   );
+   Console.Error.WriteLine("ready");
+   nvim.WaitForDisconnect();
+   ```
+   Standard output is the MessagePack RPC stream. Write diagnostics only to
+   standard error.
+3. Publish the module:
+   ```sh
+   dotnet publish --output publish
+   ```
+4. Create `example.lua` in the project directory:
+   ```lua
+   local module_path = vim.fn.getcwd() .. "/publish/NvimNetExample.dll"
+   local ready = false
+   local channel = vim.fn.jobstart(
+     { "dotnet", module_path },
+     {
+       rpc = true,
+       on_stderr = function(_, data)
+         if vim.tbl_contains(data, "ready") then
+           ready = true
+         end
+       end,
+     }
+   )
+   assert(channel > 0, "failed to start the .NET module")
+   assert(vim.wait(5000, function()
+     return ready
+   end), "timed out waiting for the .NET module")
 
-Start the module from Lua and own the Neovim bindings there:
-
-```lua
-local channel = vim.fn.jobstart(
-  { "dotnet", "run", "--project", "/path/to/MyModule.csproj" },
-  { rpc = true }
-)
-
-vim.api.nvim_create_user_command("ExampleAdd", function()
-  print(vim.fn.rpcrequest(channel, "example.add", 1, 2))
-end, {})
-
-vim.api.nvim_create_autocmd("BufEnter", {
-  pattern = "*.cs",
-  callback = function(args)
-    vim.fn.rpcnotify(channel, "example.buf-enter", args.file)
-  end,
-})
-```
+   vim.api.nvim_create_user_command("ExampleAdd", function()
+     print(vim.fn.rpcrequest(channel, "example.add", 1, 2))
+   end, {})
+   ```
+5. Start Neovim from the project directory and run `:ExampleAdd`:
+   ```sh
+   nvim --clean -u example.lua
+   ```
 
 Build
 -----

--- a/test/NvimClient.Test/NvimTests.cs
+++ b/test/NvimClient.Test/NvimTests.cs
@@ -212,12 +212,13 @@ namespace NvimClient.Test
       await File.WriteAllTextAsync(
         scriptPath,
         """
+        local module_path = assert(arg[1], "missing .NET module path")
         local channel
         local ready = false
 
         local ok, error_message = xpcall(function()
           channel = vim.fn.jobstart(
-            { "dotnet", vim.env.NVIM_CLIENT_TEST_MODULE },
+            { "dotnet", module_path },
             {
               rpc = true,
               on_stderr = function(_, data)
@@ -262,12 +263,9 @@ namespace NvimClient.Test
       };
       startInfo.ArgumentList.Add("--clean");
       startInfo.ArgumentList.Add("--headless");
-      startInfo.ArgumentList.Add("-c");
-      startInfo.ArgumentList.Add("lua dofile(vim.env.NVIM_CLIENT_TEST_SCRIPT)");
-      startInfo.Environment["NVIM_CLIENT_TEST_MODULE"] = typeof(Module.Program)
-        .Assembly
-        .Location;
-      startInfo.Environment["NVIM_CLIENT_TEST_SCRIPT"] = scriptPath;
+      startInfo.ArgumentList.Add("-l");
+      startInfo.ArgumentList.Add(scriptPath);
+      startInfo.ArgumentList.Add(typeof(Module.Program).Assembly.Location);
 
       using var process = Process.Start(startInfo);
 


### PR DESCRIPTION
Removes environment-variable plumbing from the Neovim RPC integration test.

Adds a minimal, ready-to-run RPC module example to the README.

Follow-up to #37.